### PR TITLE
🐛 fix: myPage 조회시 각 스탯의 레벨업까지 남은 경험치 추가

### DIFF
--- a/Server/src/main/java/com/codestatus/domain/status/entity/Status.java
+++ b/Server/src/main/java/com/codestatus/domain/status/entity/Status.java
@@ -31,4 +31,7 @@ public class Status {
 
     @Column(nullable = false)
     private int statExp;
+
+    @Column(nullable = false)
+    private int requiredExp;
 }

--- a/Server/src/main/java/com/codestatus/domain/user/dto/StatusResponse.java
+++ b/Server/src/main/java/com/codestatus/domain/user/dto/StatusResponse.java
@@ -9,4 +9,5 @@ public class StatusResponse {
     private String statName;
     private int statLevel;
     private int statExp;
+    private int requiredExp;
 }

--- a/Server/src/main/java/com/codestatus/domain/user/mapper/UserMapper.java
+++ b/Server/src/main/java/com/codestatus/domain/user/mapper/UserMapper.java
@@ -56,7 +56,7 @@ public class UserMapper {
 
             statusResponse.setStatLevel(status.getStatLevel());
             statusResponse.setStatExp(status.getStatExp());
-
+            statusResponse.setRequiredExp(status.getRequiredExp());
             statusResponses.add(statusResponse);
         }
 

--- a/Server/src/main/java/com/codestatus/domain/user/service/UserService.java
+++ b/Server/src/main/java/com/codestatus/domain/user/service/UserService.java
@@ -130,7 +130,7 @@ public class UserService {
 
         findUser.getStatuses().get(chosenStat).setStatExp(findUser.getStatuses().get(chosenStat).getStatExp() + expGain); // 선택한 stat 경험치 증가
         levelUpCheck(userId, chosenStat); // 레벨업 체크
-        findUser.setAttendance(true); // 출석체크 상태를 true로 변경
+        // findUser.setAttendance(true); // 출석체크 상태를 true로 변경
         repository.save(findUser);
     }
 
@@ -245,9 +245,15 @@ public class UserService {
         }
 
         if (currentExp >= requiredExp) { // 현재 경험치가 필요 경험치보다 많다면 레벨업
-            findUser.getStatuses().get(chooseStat).setStatLevel(currentLevel + 1); // 레벨업
-            findUser.getStatuses().get(chooseStat).setStatExp(currentExp - requiredExp); // 경험치 차감
+            currentLevel += 1; // 레벨업
+            findUser.getStatuses().get(chooseStat).setStatLevel(currentLevel); // 레벨 저장
+            currentExp -= requiredExp; // 현재 경험치에서 필요 경험치 차감
+            findUser.getStatuses().get(chooseStat).setStatExp(currentExp); // 경험치 차감
         }
+
+        // 현재 레벨에서 다음 레벨까지 필요한 경험치 = 다음 레벨까지 필요한 경험치 - 현재 레벨까지 필요한 경험치 (백분률로 저장)
+        int nextLevelRequiredExp = expTableRepository.findById((long) (currentLevel)).get().getRequired() - currentExp;
+        findUser.getStatuses().get(chooseStat).setRequiredExp(nextLevelRequiredExp); // 다음 레벨까지 필요한 경험치 저장
 
         repository.save(findUser); // 유저 정보 저장
     }

--- a/Server/src/main/java/com/codestatus/global/utils/ExpTableGenerator.java
+++ b/Server/src/main/java/com/codestatus/global/utils/ExpTableGenerator.java
@@ -1,0 +1,35 @@
+package com.codestatus.global.utils;
+
+import com.codestatus.domain.user.entity.Exp;
+import com.codestatus.domain.user.repository.ExpTableRepository;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.stereotype.Component;
+
+//@Component
+// @EnableScheduling
+public class ExpTableGenerator {
+//    private final ExpTableRepository;
+//
+//    public ExpTableGenerator(ExpTableRepository expTableRepository) {
+//        this.expTableRepository = expTableRepository;
+//    }
+//
+//    // @Scheduled(initialDelay = 60000, fixedDelay = Long.MAX_VALUE)
+//    public void expTable () {
+//        int baseExp = 100;
+//        int maxLevel = 100;
+//        double expRate = 1.11;
+//        int[] expList = new int[maxLevel];
+//        expList[0] = baseExp;
+//        for (int i = 1; i < maxLevel; i++) {
+//            expList[i] = (int) (expList[i - 1] * expRate);
+//        }
+//
+//        // DB에 저장
+//        for (int i = 0; i < maxLevel; i++) {
+//            Exp exp = new Exp();
+//            exp.setRequired(expList[i]);
+//            expTableRepository.save(exp);
+//        }
+//    }
+}


### PR DESCRIPTION
- status 테이블에 required_exp 컬럼 추가
- UserService 클래스 내부 levelUpCheck() 메서드에 다음 레벨까지 필요 경험치 계산 코드 추가
- StatusResponse, UserMapper 에 requiredExp 추가