### PR TITLE
✨  feat:get categories with stat id  API 추가

### DIFF
--- a/Server/src/main/java/com/codestatus/domain/category/dto/CategoryResponseDto.java
+++ b/Server/src/main/java/com/codestatus/domain/category/dto/CategoryResponseDto.java
@@ -1,0 +1,12 @@
+package com.codestatus.domain.category.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CategoryResponseDto {
+    private long categoryCode;
+
+    private String categoryName;
+}

--- a/Server/src/main/java/com/codestatus/domain/status/controller/StatController.java
+++ b/Server/src/main/java/com/codestatus/domain/status/controller/StatController.java
@@ -1,0 +1,36 @@
+package com.codestatus.domain.status.controller;
+
+import com.codestatus.domain.status.dto.StatResponseDto;
+import com.codestatus.domain.status.entity.Stat;
+import com.codestatus.domain.status.mapper.StatMapper;
+import com.codestatus.domain.status.service.StatService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+
+@Validated
+@RestController
+@RequestMapping("/stat")
+public class StatController {
+    private final StatService statService;
+    private final StatMapper statMapper;
+
+    public StatController(StatService statService, StatMapper statMapper) {
+        this.statService = statService;
+        this.statMapper = statMapper;
+    }
+
+    @GetMapping("/{statId}")
+    public ResponseEntity getStatCategory(@PathVariable("statId")@Min(1)@Max(5) long statId) {
+        Stat stat = statService.findStat(statId);
+        StatResponseDto statResponseDto = statMapper.statToStatResponseDto(stat);
+        return new ResponseEntity<>(statResponseDto, HttpStatus.OK);
+    }
+}

--- a/Server/src/main/java/com/codestatus/domain/status/dto/StatResponseDto.java
+++ b/Server/src/main/java/com/codestatus/domain/status/dto/StatResponseDto.java
@@ -1,0 +1,17 @@
+package com.codestatus.domain.status.dto;
+
+import com.codestatus.domain.category.dto.CategoryResponseDto;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class StatResponseDto {
+    private long statCode;
+
+    private String statName;
+
+    private List<CategoryResponseDto> categories;
+}

--- a/Server/src/main/java/com/codestatus/domain/status/entity/Stat.java
+++ b/Server/src/main/java/com/codestatus/domain/status/entity/Stat.java
@@ -1,10 +1,13 @@
 package com.codestatus.domain.status.entity;
 
+import com.codestatus.domain.category.entity.Category;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -16,4 +19,7 @@ public class Stat {
     private Long statId;
 
     private String statName;
+
+    @OneToMany(mappedBy = "stat")
+    private List<Category> categories = new ArrayList<>();
 }

--- a/Server/src/main/java/com/codestatus/domain/status/mapper/StatMapper.java
+++ b/Server/src/main/java/com/codestatus/domain/status/mapper/StatMapper.java
@@ -1,0 +1,24 @@
+package com.codestatus.domain.status.mapper;
+
+import com.codestatus.domain.category.dto.CategoryResponseDto;
+import com.codestatus.domain.status.dto.StatResponseDto;
+import com.codestatus.domain.status.entity.Stat;
+import org.springframework.stereotype.Component;
+
+import java.util.stream.Collectors;
+
+@Component
+public class StatMapper {
+    public StatResponseDto statToStatResponseDto(Stat stat){
+        return StatResponseDto.builder()
+                .statCode(stat.getStatId())
+                .statName(stat.getStatName())
+                .categories(stat.getCategories().stream()
+                        .map(category -> CategoryResponseDto.builder()
+                                .categoryCode(category.getCategoryId())
+                                .categoryName(category.getCategory())
+                                .build())
+                        .collect(Collectors.toList()))
+                .build();
+    }
+}

--- a/Server/src/main/java/com/codestatus/domain/status/service/StatService.java
+++ b/Server/src/main/java/com/codestatus/domain/status/service/StatService.java
@@ -1,0 +1,25 @@
+package com.codestatus.domain.status.service;
+
+import com.codestatus.domain.status.entity.Stat;
+import com.codestatus.domain.status.repository.StatRepository;
+import com.codestatus.global.exception.BusinessLogicException;
+import com.codestatus.global.exception.ExceptionCode;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Transactional(readOnly = true)
+@Service
+public class StatService {
+    private final StatRepository statRepository;
+
+    public StatService(StatRepository statRepository) {
+        this.statRepository = statRepository;
+    }
+
+    public Stat findStat(long statId){
+        Optional<Stat> optionalStat = statRepository.findById(statId);
+        return optionalStat.orElseThrow(() -> new BusinessLogicException(ExceptionCode.STAT_NOT_FOUND));
+    }
+}

--- a/Server/src/main/java/com/codestatus/global/exception/ExceptionCode.java
+++ b/Server/src/main/java/com/codestatus/global/exception/ExceptionCode.java
@@ -18,7 +18,8 @@ public enum ExceptionCode {
     INVALID_FILE_TYPE(400, "이미지 파일만 업로드 가능합니다."),
     FILE_TOO_LARGE(400, "파일 크기는 5MB를 넘을 수 없습니다."),
     COMMENT_NOT_FOUND(404, "댓글을 찾을 수 없습니다."),
-    FORBIDDEN_REQUEST(403, "해당 리소스에 접근이 불가능합니다.");
+    FORBIDDEN_REQUEST(403, "해당 리소스에 접근이 불가능합니다."),
+    STAT_NOT_FOUND(404, "스탯을 찾을 수 없습니다.");
 
 //    NOT_IMPLEMENTATION(501, "해당 기능은 구현되지 않았습니다.");
 


### PR DESCRIPTION
✨  feat:get categories with stat id  API 추가
- stat id로 해당 스탯과 관련한 카테고리 리스트를 보여주는 api를 추가하였습니다.
- stat id가 1이상 5이하의 stat만 조회가 가능합니다.

Test Case
- 로컬에서 postman으로 request 확인하였습니다.
- 1이상 5이하의 stat id만 조회 가능한지 확인하였습니다.