### PR TITLE
♻ refactor: user service에서 level service 분리

### DIFF
--- a/Server/src/main/java/com/codestatus/domain/like/service/LikeService.java
+++ b/Server/src/main/java/com/codestatus/domain/like/service/LikeService.java
@@ -5,6 +5,7 @@ import com.codestatus.domain.like.repository.LikeRepository;
 import com.codestatus.domain.feed.entity.Feed;
 import com.codestatus.domain.like.entity.Like;
 import com.codestatus.domain.user.entity.User;
+import com.codestatus.domain.user.service.LevelService;
 import com.codestatus.domain.user.service.UserService;
 import com.codestatus.global.exception.BusinessLogicException;
 import com.codestatus.global.exception.ExceptionCode;
@@ -20,10 +21,12 @@ public class LikeService {
     @Value("${exp.like-exp}")
     private int likeExp;
     private final UserService userService;
+    private final LevelService levelService;
     private final FeedService feedService;
     private final LikeRepository likeRepository;
 
-    public LikeService(UserService userService, FeedService feedService, LikeRepository likeRepository) {
+    public LikeService(UserService userService, LevelService levelService, FeedService feedService, LikeRepository likeRepository) {
+        this.levelService = levelService;
         this.userService = userService;
         this.feedService = feedService;
         this.likeRepository = likeRepository;
@@ -48,7 +51,7 @@ public class LikeService {
             like.setFeed(feed);
             like.setUser(user);
             // 경험치 획득 및 level up  check 메서드
-            userService.gainExp(feed.getUser(), likeExp, feed.getCategory().getStat().getStatId().intValue());
+            levelService.gainExp(feed.getUser(), likeExp, feed.getCategory().getStat().getStatId().intValue());
         }
         likeRepository.save(like);
     }

--- a/Server/src/main/java/com/codestatus/domain/user/controller/UserController.java
+++ b/Server/src/main/java/com/codestatus/domain/user/controller/UserController.java
@@ -3,9 +3,12 @@ package com.codestatus.domain.user.controller;
 import com.codestatus.domain.user.dto.UserDto;
 import com.codestatus.domain.user.entity.User;
 import com.codestatus.domain.user.mapper.UserMapper;
+import com.codestatus.domain.user.service.LevelService;
 import com.codestatus.domain.user.service.UserService;
+import com.codestatus.global.auth.dto.PrincipalDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.multipart.MultipartFile;
@@ -20,62 +23,68 @@ import javax.validation.constraints.Min;
 public class UserController {
     private final UserMapper userMapper;
     private final UserService service;
+    private final LevelService levelService;
 
-    public UserController(UserMapper userMapper, UserService service) {
+    public UserController(UserMapper userMapper, UserService service, LevelService levelService) {
         this.userMapper = userMapper;
         this.service = service;
+        this.levelService = levelService;
     }
 
     // 유저 가입 컨트롤러
     @PostMapping("/signup")
     public ResponseEntity postUser(@Valid @RequestBody UserDto.signup requestBody) {
         User newUser = userMapper.userPostToUser(requestBody); // PostDto -> Entity
-        service.createUser(newUser); // 유저 가입 메서드 호출
+        service.createEntity(newUser); // 유저 가입 메서드 호출
         return ResponseEntity.status(HttpStatus.CREATED).body("signup success"); // 가입 성공 메시지 반환
     }
 
     // 유저 조회 컨트롤러
     @GetMapping("/mypage")
-    public ResponseEntity<UserDto.Response> getUser() {
-        User user = service.findUser(); // 유저 조회 메서드 호출
+    public ResponseEntity<UserDto.Response> getUser(@AuthenticationPrincipal PrincipalDto principal) {
+        User user = service.findEntity(principal.getId()); // 유저 조회 메서드 호출
         UserDto.Response responseBody = userMapper.userToUserResponse(user); // Entity -> ResponseDto
         return ResponseEntity.status(HttpStatus.OK).body(responseBody); // 유저 정보 반환
     }
 
     // 유저 닉네임 수정 컨트롤러
     @PatchMapping("/mypage/edit/nickname")
-    public ResponseEntity patchUserNickName(@Valid @RequestBody UserDto.PatchNickName requestBody) {
+    public ResponseEntity patchUserNickName(@Valid @RequestBody UserDto.PatchNickName requestBody,
+                                            @AuthenticationPrincipal PrincipalDto principal) {
         User user = userMapper.userPatchToUser(requestBody); // PatchDto -> Entity
-        service.updateUserNickName(user); // 유저 닉네임 수정 메서드 호출
+        service.updateUserNickName(user, principal.getId()); // 유저 닉네임 수정 메서드 호출
         return ResponseEntity.status(HttpStatus.OK).body("nickname patch success"); // 닉네임 수정 성공 메시지 반환
     }
 
     // 유저 비밀번호 수정 컨트롤러
     @PatchMapping("/mypage/edit/password")
-    public ResponseEntity patchUserPassword(@Valid @RequestBody UserDto.PatchPassword requestBody) {
+    public ResponseEntity patchUserPassword(@Valid @RequestBody UserDto.PatchPassword requestBody,
+                                            @AuthenticationPrincipal PrincipalDto principal) {
         User user = userMapper.userPatchPasswordToUser(requestBody); // PatchDto -> Entity
-        service.updatePassword(user); // 유저 비밀번호 수정 메서드 호출
+        service.updatePassword(user, principal.getId()); // 유저 비밀번호 수정 메서드 호출
         return ResponseEntity.status(HttpStatus.OK).body("password patch success"); // 비밀번호 수정 성공 메시지 반환
     }
 
     // 출석체크 컨트롤러
     @PostMapping("/mypage/attendance/{chosenStat}")
-    public ResponseEntity checkAttendance(@PathVariable @Min(0) @Max(4) int chosenStat) {
-        service.checkAttendance(chosenStat); // 출석체크 메서드 호출
+    public ResponseEntity checkAttendance(@PathVariable @Min(0) @Max(4) int chosenStat,
+                                          @AuthenticationPrincipal PrincipalDto principal) {
+        levelService.checkAttendance(chosenStat, principal.getId()); // 출석체크 메서드 호출
         return ResponseEntity.status(HttpStatus.OK).body("attendance check success"); // 출석체크 성공 메시지 반환
     }
 
     // 프로필 이미지 업로드
     @PostMapping("/mypage/edit/image")
-    public ResponseEntity uploadProfileImage(@RequestParam("imageFile") MultipartFile imageFile) {
+    public ResponseEntity uploadProfileImage(@RequestParam("imageFile") MultipartFile imageFile,
+                                             @AuthenticationPrincipal PrincipalDto principal) {
         service.uploadProfileImage(imageFile); // 프로필 이미지 업로드 메서드 호출
         return ResponseEntity.status(HttpStatus.OK).body("profile image upload success"); // 프로필 이미지 업로드 성공 메시지 반환
     }
 
     // 유저 탈퇴
     @DeleteMapping("/mypage/delete")
-    public ResponseEntity deleteUser() {
-        service.deleteUser(); // 유저 탈퇴 메서드 호출
+    public ResponseEntity deleteUser(@AuthenticationPrincipal PrincipalDto principal) {
+        service.deleteEntity(principal.getId(), principal.getId()); // 유저 탈퇴 메서드 호출
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build(); // 유저 탈퇴 성공
     }
 }

--- a/Server/src/main/java/com/codestatus/domain/user/controller/UserController.java
+++ b/Server/src/main/java/com/codestatus/domain/user/controller/UserController.java
@@ -77,7 +77,7 @@ public class UserController {
     @PostMapping("/mypage/edit/image")
     public ResponseEntity uploadProfileImage(@RequestParam("imageFile") MultipartFile imageFile,
                                              @AuthenticationPrincipal PrincipalDto principal) {
-        service.uploadProfileImage(imageFile); // 프로필 이미지 업로드 메서드 호출
+        service.uploadProfileImage(imageFile, principal.getId()); // 프로필 이미지 업로드 메서드 호출
         return ResponseEntity.status(HttpStatus.OK).body("profile image upload success"); // 프로필 이미지 업로드 성공 메시지 반환
     }
 

--- a/Server/src/main/java/com/codestatus/domain/user/service/LevelService.java
+++ b/Server/src/main/java/com/codestatus/domain/user/service/LevelService.java
@@ -1,2 +1,70 @@
-package com.codestatus.domain.user.service;public class LevelService {
+package com.codestatus.domain.user.service;
+
+import com.codestatus.domain.user.entity.User;
+import com.codestatus.domain.user.repository.ExpTableRepository;
+import com.codestatus.domain.user.repository.UserRepository;
+import com.codestatus.global.exception.BusinessLogicException;
+import com.codestatus.global.exception.ExceptionCode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@Service
+public class LevelService {
+    @Value("${exp.attendance-exp}")
+    private int attendanceExp;
+    private final UserRepository userRepository;
+    private final ExpTableRepository expTableRepository;
+    private final UserService userService;
+
+    public LevelService(UserRepository userRepository, ExpTableRepository expTableRepository, UserService userService) {
+        this.userRepository = userRepository;
+        this.expTableRepository = expTableRepository;
+        this.userService = userService;
+    }
+    // 출석체크
+    public void checkAttendance(int chosenStat, long loginId) { // chosenStat: 0(str), 1(dex), 2(int), 3(charm), 4(vitality)
+        User findUser = userService.findVerifiedUser(loginId); // 유저 검증 메서드(유저가 존재하지 않으면 예외처리)
+
+        if(findUser.isAttendance()) { // 이미 출석체크를 했다면 예외 발생
+            throw new BusinessLogicException(ExceptionCode.USER_ALREADY_CHECKED_ATTENDANCE);
+        }
+
+        findUser.getStatuses().get(chosenStat).setStatExp(findUser.getStatuses().get(chosenStat).getStatExp() + attendanceExp); // 선택한 stat 경험치 증가
+        levelUpCheck(findUser, chosenStat); // 레벨업 체크
+        findUser.setAttendance(true); // 출석체크 상태를 true로 변경
+        userRepository.save(findUser);
+    }
+
+    public void gainExp(User user, int exp, int statId) {
+        user.getStatuses().get(statId-1).setStatExp(
+                user.getStatuses().get(statId-1).getStatExp() + exp
+        );
+        levelUpCheck(user, statId-1);
+    }
+
+    private void levelUpCheck(User user, int chooseStat) { // chooseStat: 0(str), 1(dex), 2(int), 3(charm), 4(vitality)
+        int currentLevel = user.getStatuses().get(chooseStat).getStatLevel(); // 현재 레벨
+        int currentExp = user.getStatuses().get(chooseStat).getStatExp(); // 현재 경험치
+        int requiredExp = expTableRepository.findById((long) currentLevel).get().getRequired(); // 필요 경험치
+        int maxLevel = 100; // 최대 레벨
+
+        if (currentLevel >= maxLevel) { // 현재 레벨이 최대 레벨이라면 레벨업 불가
+            return;
+        }
+
+        if (currentExp >= requiredExp) { // 현재 경험치가 필요 경험치보다 많다면 레벨업
+            currentLevel += 1; // 레벨업
+            user.getStatuses().get(chooseStat).setStatLevel(currentLevel); // 레벨 저장
+            currentExp -= requiredExp; // 현재 경험치에서 필요 경험치 차감
+            user.getStatuses().get(chooseStat).setStatExp(currentExp); // 경험치 차감
+        }
+
+        // 현재 레벨에서 다음 레벨까지 필요한 경험치 = 다음 레벨까지 필요한 경험치 - 현재 레벨까지 필요한 경험치 (백분률로 저장)
+        int nextLevelRequiredExp = expTableRepository.findById((long) (currentLevel)).get().getRequired() - currentExp;
+        user.getStatuses().get(chooseStat).setRequiredExp(nextLevelRequiredExp); // 다음 레벨까지 필요한 경험치 저장
+
+        userRepository.save(user); // 유저 정보 저장
+    }
 }

--- a/Server/src/main/java/com/codestatus/domain/user/service/LevelService.java
+++ b/Server/src/main/java/com/codestatus/domain/user/service/LevelService.java
@@ -1,0 +1,2 @@
+package com.codestatus.domain.user.service;public class LevelService {
+}


### PR DESCRIPTION
♻ refactor: user service에서 level service 분리
- user service에서 레벨 관련 기능을 분리해서 level service를 추가하였습니다.
- user service에서 회원가입 할 때 stat별 status를 생성하는 로직을 줄였습니다.
- user controller에서 @AuthenticationPrincipal을 통해 principal을 service에 전달하여 사용하도록 하였습니다.

Test Case
- postman을 통해 회원가입, 로그인, 피드 좋아요 기능 확인하였습니다.