### PR TITLE
♻️ refactor: 유저 정보 조회 커스텀 훅

### DIFF
--- a/Client/src/api/auth.ts
+++ b/Client/src/api/auth.ts
@@ -1,21 +1,17 @@
-import axios from "axios";
-
+import axios from 'axios';
 
 interface UserData {
-    email: string;
-    password: string;
-    nickname?: string;
+  email: string;
+  password: string;
+  nickname?: string;
 }
 
-
-
 export const registerAuth = async (userData: UserData) => {
-    const response = await axios.post('user/users.json', userData);
-    return response.data;
+  const response = await axios.post('user/users.json', userData);
+  return response.data;
 };
 
-
 export const loginAuth = async (userData: UserData) => {
-    const response = await axios.post('user/users.json', userData);
-    return response.data;
+  const response = await axios.post('user/users.json', userData);
+  return response.data;
 };

--- a/Client/src/api/user.ts
+++ b/Client/src/api/user.ts
@@ -1,0 +1,27 @@
+import axios from 'axios';
+
+export interface Status {
+  statName: string;
+  statLevel: number;
+  statExp: number;
+  requiredExp: number;
+}
+
+export interface UserInfo {
+  id: number;
+  email: string;
+  nickName: string;
+  profileImage: string;
+  attendance: boolean;
+  statuses: Status[];
+}
+
+export const getUserInfo = async (): Promise<UserInfo> => {
+  const res = await axios.get('user/test.json');
+  return res.data;
+};
+
+export const getUserStatus = async (): Promise<Status[]> => {
+  const res = await axios.get('user/test.json');
+  return res.data.statuses;
+};

--- a/Client/src/api/user.ts
+++ b/Client/src/api/user.ts
@@ -20,8 +20,3 @@ export const getUserInfo = async (): Promise<UserInfo> => {
   const res = await axios.get('user/test.json');
   return res.data;
 };
-
-export const getUserStatus = async (): Promise<Status[]> => {
-  const res = await axios.get('user/test.json');
-  return res.data.statuses;
-};

--- a/Client/src/components/title/ProfileScreen.tsx
+++ b/Client/src/components/title/ProfileScreen.tsx
@@ -1,26 +1,25 @@
+import useUserInfo from '../../hooks/useUserInfo';
 import Backdrop from '../common/Backdrop';
 import Button from '../common/Button';
-import { useEffect, useState } from 'react';
-import { UserInfo, getUserInfo } from '../../api/user';
+import { useState } from 'react';
 
 interface Props {
-  showDefault?: () => void;
+  showDefault: () => void;
 }
 
 const ProfileScreen = ({ showDefault }: Props) => {
-  const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
   const [tab, setTab] = useState<'password' | 'post'>('post');
 
-  useEffect(() => {
-    (async () => {
-      try {
-        const userInfo = await getUserInfo();
-        setUserInfo(userInfo);
-      } catch (error) {
-        console.log(error);
-      }
-    })();
-  }, []);
+  const { userInfoQuery } = useUserInfo();
+  const { isLoading, data: userInfo } = userInfoQuery;
+
+  if (isLoading) return <div>Loading...</div>;
+
+  if (!userInfo) {
+    alert('정보를 불러오는 데 실패했습니다.');
+    showDefault();
+    return null;
+  }
   return (
     <Backdrop>
       <div className="relative w-full h-full flex flex-col justify-center items-center gap-[2rem]">
@@ -31,7 +30,7 @@ const ProfileScreen = ({ showDefault }: Props) => {
               <div className="w-[150px] h-[150px] bg-[url('/src/assets/common/profile-frame.png')] bg-center bg-cover bg-no-repeat flex justify-center items-center">
                 <img
                   className="w-[120px] h-[120px]"
-                  src={userInfo?.profileImage}
+                  src={userInfo.profileImage}
                   alt="profile"
                 />
               </div>
@@ -43,14 +42,14 @@ const ProfileScreen = ({ showDefault }: Props) => {
                 NAME
                 <br />
                 <span className="font-[ui-sans-serif] text-[2.5rem] font-extrabold">
-                  {userInfo?.nickName}
+                  {userInfo.nickName}
                 </span>
               </h1>
               <h1 className="text-[.8rem] text-center">
                 EMAIL
                 <br />
                 <span className="text-[.5rem] font-extrabold">
-                  {userInfo?.email}
+                  {userInfo.email}
                 </span>
               </h1>
             </div>

--- a/Client/src/components/title/ProfileScreen.tsx
+++ b/Client/src/components/title/ProfileScreen.tsx
@@ -1,23 +1,7 @@
 import Backdrop from '../common/Backdrop';
 import Button from '../common/Button';
 import { useEffect, useState } from 'react';
-import axios from 'axios';
-
-interface Status {
-  statName: string;
-  statLevel: number;
-  statExp: number;
-  requiredExp: number;
-}
-
-interface UserInfo {
-  id: number;
-  email: string;
-  nickName: string;
-  profileImage: string;
-  attendance: boolean;
-  statuses: Status[];
-}
+import { UserInfo, getUserInfo } from '../../api/user';
 
 interface Props {
   showDefault?: () => void;
@@ -30,8 +14,8 @@ const ProfileScreen = ({ showDefault }: Props) => {
   useEffect(() => {
     (async () => {
       try {
-        const { data }: { data: UserInfo } = await axios.get('user/test.json');
-        setUserInfo(data);
+        const userInfo = await getUserInfo();
+        setUserInfo(userInfo);
       } catch (error) {
         console.log(error);
       }

--- a/Client/src/components/title/StatusChart.tsx
+++ b/Client/src/components/title/StatusChart.tsx
@@ -9,6 +9,7 @@ import {
   Legend,
 } from 'chart.js';
 import { useEffect, useState } from 'react';
+import { Status } from '../../api/user';
 
 ChartJS.register(
   RadialLinearScale,
@@ -18,13 +19,6 @@ ChartJS.register(
   Tooltip,
   Legend,
 );
-
-interface Status {
-  statName: string;
-  statLevel: number;
-  statExp: number;
-  requiredExp: number;
-}
 
 interface Props {
   status: Status[];

--- a/Client/src/components/title/StatusListItem.tsx
+++ b/Client/src/components/title/StatusListItem.tsx
@@ -1,12 +1,6 @@
 import { titleIcons } from '../../utility/icon';
 import { Link } from 'react-router-dom';
-
-interface Status {
-  statName: string;
-  statLevel: number;
-  statExp: number;
-  requiredExp: number;
-}
+import { Status } from '../../api/user';
 
 interface Props {
   status: Status;

--- a/Client/src/components/title/StatusScreen.tsx
+++ b/Client/src/components/title/StatusScreen.tsx
@@ -1,28 +1,12 @@
 import { useEffect, useState } from 'react';
 import Backdrop from '../common/Backdrop';
 import Button from '../common/Button';
-import axios from 'axios';
 import StatusChart from './StatusChart';
 import StatusListItem from './StatusListItem';
+import { Status, getUserStatus } from '../../api/user';
 
 interface Props {
   showDefault?: () => void;
-}
-
-interface Status {
-  statName: string;
-  statLevel: number;
-  statExp: number;
-  requiredExp: number;
-}
-
-interface UserInfo {
-  id: number;
-  email: string;
-  nickName: string;
-  profileImage: string;
-  attendance: boolean;
-  statuses: Status[];
 }
 
 const StatusScreen = ({ showDefault }: Props) => {
@@ -31,8 +15,8 @@ const StatusScreen = ({ showDefault }: Props) => {
   useEffect(() => {
     (async () => {
       try {
-        const { data }: { data: UserInfo } = await axios.get('user/test.json');
-        setStatus(data.statuses);
+        const userStatus = await getUserStatus();
+        setStatus(userStatus);
       } catch (error) {
         console.log(error);
       }

--- a/Client/src/components/title/StatusScreen.tsx
+++ b/Client/src/components/title/StatusScreen.tsx
@@ -1,27 +1,26 @@
-import { useEffect, useState } from 'react';
 import Backdrop from '../common/Backdrop';
 import Button from '../common/Button';
 import StatusChart from './StatusChart';
 import StatusListItem from './StatusListItem';
-import { Status, getUserStatus } from '../../api/user';
+import useUserInfo from '../../hooks/useUserInfo';
 
 interface Props {
-  showDefault?: () => void;
+  showDefault: () => void;
 }
 
 const StatusScreen = ({ showDefault }: Props) => {
-  const [status, setStatus] = useState<Status[]>([]);
+  const { userInfoQuery } = useUserInfo();
+  const { isLoading, data } = userInfoQuery;
+  const status = data?.statuses;
 
-  useEffect(() => {
-    (async () => {
-      try {
-        const userStatus = await getUserStatus();
-        setStatus(userStatus);
-      } catch (error) {
-        console.log(error);
-      }
-    })();
-  }, []);
+  if (isLoading) return <div>Loading...</div>;
+
+  if (!status) {
+    alert('정보를 불러오는 데 실패했습니다.');
+    showDefault();
+    return null;
+  }
+
   return (
     <Backdrop>
       <div className="relative w-full h-full flex flex-col justify-center items-center gap-[2rem]">

--- a/Client/src/hooks/useUserInfo.tsx
+++ b/Client/src/hooks/useUserInfo.tsx
@@ -1,0 +1,10 @@
+import { useQuery } from 'react-query';
+import { getUserInfo } from '../api/user';
+
+export default function useUserInfo() {
+  const userInfoQuery = useQuery(['userInfo'], getUserInfo, {
+    staleTime: 1000 * 60,
+  });
+
+  return { userInfoQuery };
+}

--- a/Client/src/pages/TitlePage.tsx
+++ b/Client/src/pages/TitlePage.tsx
@@ -30,7 +30,7 @@ const TitlePage = () => {
           className="relative bg-title w-[1200px] h-[720px] bg-cover
         bg-no-repeat bg-center"
         >
-          {screen === Screen.TITLE && <TitleScreen showAuth={showAuth} />}
+          {screen === Screen.TITLE && <TitleScreen showAuth={showDefault} />}
           {screen === Screen.AUTH && <AuthScreen showDefault={showDefault} />}
           {screen === Screen.STATUS && (
             <StatusScreen showDefault={showDefault} />

--- a/Client/src/pages/TitlePage.tsx
+++ b/Client/src/pages/TitlePage.tsx
@@ -30,7 +30,7 @@ const TitlePage = () => {
           className="relative bg-title w-[1200px] h-[720px] bg-cover
         bg-no-repeat bg-center"
         >
-          {screen === Screen.TITLE && <TitleScreen showAuth={showDefault} />}
+          {screen === Screen.TITLE && <TitleScreen showAuth={showAuth} />}
           {screen === Screen.AUTH && <AuthScreen showDefault={showDefault} />}
           {screen === Screen.STATUS && (
             <StatusScreen showDefault={showDefault} />


### PR DESCRIPTION
https://github.com/codestates-seb/seb45_main_022/blob/ce8d5a2f475f96d53d63df558293025b8ce80354/Client/src/api/user.ts#L19-L22
`ProfileScreen`, `StatusScreen` 컴포넌트 내에서 유저 정보 조회 API 요청하던 코드 따로 분리

<br />

https://github.com/codestates-seb/seb45_main_022/blob/ce8d5a2f475f96d53d63df558293025b8ce80354/Client/src/hooks/useUserInfo.tsx#L4-L10
**React query**를 사용해 유저 정보를 관리하는  `useUserInfo`  커스텀 훅 작성

<br />


https://github.com/codestates-seb/seb45_main_022/blob/ce8d5a2f475f96d53d63df558293025b8ce80354/Client/src/components/title/ProfileScreen.tsx#L13-L22
https://github.com/codestates-seb/seb45_main_022/blob/ce8d5a2f475f96d53d63df558293025b8ce80354/Client/src/components/title/StatusScreen.tsx#L12-L22
`ProfileScreen`, `StatusScreen` 컴포넌트에서 `useUserInfo`를 사용해 데이터 페칭