### PR TITLE
🐛 fix: 유저 정보 조회 response 일부 변경

### DIFF
--- a/Server/src/main/java/com/codestatus/domain/user/dto/StatusResponse.java
+++ b/Server/src/main/java/com/codestatus/domain/user/dto/StatusResponse.java
@@ -6,7 +6,7 @@ import lombok.Setter;
 @Getter
 @Setter
 public class StatusResponse {
-    private String statName;
+    private int statId;
     private int statLevel;
     private int statExp;
     private int requiredExp;

--- a/Server/src/main/java/com/codestatus/domain/user/mapper/UserMapper.java
+++ b/Server/src/main/java/com/codestatus/domain/user/mapper/UserMapper.java
@@ -51,7 +51,7 @@ public class UserMapper {
 
             Stat stat = status.getStat();
             if (stat != null) {
-                statusResponse.setStatName(stat.getStatName());
+                statusResponse.setStatId(stat.getStatId().intValue());
             }
 
             statusResponse.setStatLevel(status.getStatLevel());


### PR DESCRIPTION
- 유저 정보 조회시 response에 포함된 statuses 의 statName 을 statId 로 응답하게 변경