### PR TITLE
♻️ refactor: 스테이터스 코드, 카테고리 코드 값을 통해 스테이터스, 카테고리 정보를 가져올 수 있도록 수정

### DIFF
--- a/Client/public/user/test.json
+++ b/Client/public/user/test.json
@@ -2,40 +2,40 @@
   "id": 1,
   "email": "black@dragon.luv",
   "nickName": "흑룡",
-  "profileImage": "https://codestatus.s3.ap-northeast-2.amazonaws.com/default_profile_image1.png",
+  "profileImage": "https://codestatus.s3.ap-northeast-2.amazonaws.com/1693231015736_test.jpg",
   "attendance": false,
   "statuses": [
     {
-      "statName": "힘",
-      "statLevel": 6,
-      "statExp": 10,
-      "requiredExp": 100
+      "statId": 1,
+      "statLevel": 3,
+      "statExp": 120,
+      "requiredExp": 3
     },
     {
-      "statName": "민첩",
+      "statId": 2,
       "statLevel": 2,
-      "statExp": 2,
-      "requiredExp": 100
+      "statExp": 70,
+      "requiredExp": 41
     },
     {
-      "statName": "지능",
-      "statLevel": 24,
-      "statExp": 69,
-      "requiredExp": 100
+      "statId": 3,
+      "statLevel": 2,
+      "statExp": 50,
+      "requiredExp": 61
     },
     {
-      "statName": "매력",
+      "statId": 4,
       "statLevel": 1,
-      "statExp": 0,
-      "requiredExp": 100
+      "statExp": 40,
+      "requiredExp": 60
     },
     {
-      "statName": "생활력",
+      "statId": 5,
       "statLevel": 1,
-      "statExp": 0,
-      "requiredExp": 100
+      "statExp": 30,
+      "requiredExp": 70
     }
   ],
   "createDate": "2023-08-28T20:29:17.611235",
-  "modifiedDate": "2023-08-28T21:36:36.822127"
+  "modifiedDate": "2023-09-04T19:43:23.545325"
 }

--- a/Client/src/api/user.ts
+++ b/Client/src/api/user.ts
@@ -1,7 +1,8 @@
 import axios from 'axios';
+import { StatusCode } from './category';
 
 export interface Status {
-  statName: string;
+  statId: StatusCode;
   statLevel: number;
   statExp: number;
   requiredExp: number;

--- a/Client/src/components/feed/Header.tsx
+++ b/Client/src/components/feed/Header.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom';
-import { STATUS_ICON } from '../../utility/icon';
-import { CATEGORY_ICON } from '../../utility/icon';
+import { STATUS_ICON } from '../../utility/status';
+import { CATEGORY_ICON } from '../../utility/category';
 
 const Header = () => {
   return (

--- a/Client/src/components/map/ServerList.tsx
+++ b/Client/src/components/map/ServerList.tsx
@@ -1,6 +1,6 @@
 import Button from '../common/Button';
 import { Link } from 'react-router-dom';
-import { CATEGORY_ICON } from '../../utility/icon';
+import { CATEGORY_ICON } from '../../utility/category';
 import { CategoryCode } from '../../api/category';
 
 interface Props {

--- a/Client/src/components/title/StatusChart.tsx
+++ b/Client/src/components/title/StatusChart.tsx
@@ -10,6 +10,7 @@ import {
 } from 'chart.js';
 import { useEffect, useState } from 'react';
 import { Status } from '../../api/user';
+import { STATUS_NAME } from '../../utility/status';
 
 ChartJS.register(
   RadialLinearScale,
@@ -29,7 +30,7 @@ const StatusChart = ({ status }: Props) => {
   const [statusLevels, setStatusLevels] = useState<number[]>([]);
 
   useEffect(() => {
-    const statusNameArray = status.map((stat) => stat.statName);
+    const statusNameArray = status.map((stat) => STATUS_NAME[stat.statId]);
     const statusLevelArray = status.map((stat) => stat.statLevel);
     setStatusNames(statusNameArray);
     setStatusLevels(statusLevelArray);

--- a/Client/src/components/title/StatusListItem.tsx
+++ b/Client/src/components/title/StatusListItem.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router-dom';
 import { Status } from '../../api/user';
 import { StatusCode } from '../../api/category';
-import { STATUS_ICON } from '../../utility/icon';
+import { STATUS_ICON } from '../../utility/status';
 
 interface Props {
   status: Status;

--- a/Client/src/components/title/StatusListItem.tsx
+++ b/Client/src/components/title/StatusListItem.tsx
@@ -1,26 +1,26 @@
 import { Link } from 'react-router-dom';
 import { Status } from '../../api/user';
-import { StatusCode } from '../../api/category';
-import { STATUS_ICON } from '../../utility/status';
+import { STATUS_ICON, STATUS_NAME } from '../../utility/status';
 
 interface Props {
   status: Status;
-  statusCode: StatusCode;
 }
 
-const StatusListItem = ({ status, statusCode }: Props) => {
-  const { statName, statLevel, statExp, requiredExp } = status;
+const StatusListItem = ({ status }: Props) => {
+  const { statId, statLevel, statExp, requiredExp } = status;
   return (
-    <Link to={`/map/${statusCode}`}>
+    <Link to={`/map/${statId}`}>
       <div className="p-3 flex flex-col justify-center items-center gap-2 bg-[#fee1b8] hover:brightness-90 rounded-md duration-300 cursor-pointer shadow-lg">
         {/* 스탯 아이콘, 이름, 레벨 */}
         <div className="flex flex-row justify-center items-end gap-3">
           <img
             className="w-[30px] h-[30px]"
-            src={STATUS_ICON[statusCode]}
+            src={STATUS_ICON[statId]}
             alt="icon"
           />
-          <span className="text-[1.5rem] font-bold leading-10">{statName}</span>{' '}
+          <span className="text-[1.5rem] font-bold leading-10">
+            {STATUS_NAME[statId]}
+          </span>{' '}
           <span className="leading-7">{`Lv.${statLevel}`}</span>
         </div>
         {/* 경험치 바 */}
@@ -28,11 +28,11 @@ const StatusListItem = ({ status, statusCode }: Props) => {
           <div
             className="h-full bg-yellow-500 rounded-full"
             style={{
-              width: `${(statExp / requiredExp) * 100}%`,
+              width: `${(statExp / (requiredExp + statExp)) * 100}%`,
             }}
           ></div>
           <span className="absolute left-3 text-xs text-gray-400">
-            {`${statExp} / ${requiredExp}`}
+            {`${statExp} / ${requiredExp + statExp}`}
           </span>
         </div>
       </div>

--- a/Client/src/components/title/StatusScreen.tsx
+++ b/Client/src/components/title/StatusScreen.tsx
@@ -11,11 +11,11 @@ interface Props {
 const StatusScreen = ({ showDefault }: Props) => {
   const { userInfoQuery } = useUserInfo();
   const { isLoading, data } = userInfoQuery;
-  const status = data?.statuses;
+  const statusData = data?.statuses;
 
   if (isLoading) return <div>Loading...</div>;
 
-  if (!status) {
+  if (!statusData) {
     alert('정보를 불러오는 데 실패했습니다.');
     showDefault();
     return null;
@@ -27,11 +27,11 @@ const StatusScreen = ({ showDefault }: Props) => {
         <div className="w-[1200px] h-[600px] p-5 bg-[url('/src/assets/common/modal-frame-note.png')] bg-center bg-cover bg-no-repeat flex flex-row justify-between">
           <div className="w-[500px] h-[600px] p-5 flex flex-col gap-[1rem] justify-center items-center">
             <h1 className="text-[2rem] ml-5">YOUR STATUS</h1>
-            <StatusChart status={status} />
+            <StatusChart status={statusData} />
           </div>
           <div className="w-[500px] h-[600px] px-5 pb-10 flex flex-col justify-center items-center gap-2">
-            {status.map((stat, i) => (
-              <StatusListItem key={i} status={stat} statusCode={i} />
+            {statusData.map((status, i) => (
+              <StatusListItem key={i} status={status} />
             ))}
           </div>
         </div>

--- a/Client/src/utility/category.ts
+++ b/Client/src/utility/category.ts
@@ -45,18 +45,18 @@ export const CATEGORY_NAME: Record<CategoryCode, string> = {
   [CategoryCode.COOKING]: '요리',
 };
 
-export const CATEGORY_STATUS_MAP: Record<CategoryCode, StatusCode[]> = {
-  [CategoryCode.WEIGHT]: [StatusCode.STR],
-  [CategoryCode.CLIMBING]: [StatusCode.STR],
-  [CategoryCode.BALLGAME]: [StatusCode.DEX],
-  [CategoryCode.ESPORTS]: [StatusCode.DEX],
-  [CategoryCode.JOGGING]: [StatusCode.DEX],
-  [CategoryCode.READING]: [StatusCode.INT],
-  [CategoryCode.STUDY]: [StatusCode.INT],
-  [CategoryCode.IT]: [StatusCode.INT],
-  [CategoryCode.BEAUTY]: [StatusCode.CHARM],
-  [CategoryCode.MUSIC]: [StatusCode.CHARM],
-  [CategoryCode.INTERIOR]: [StatusCode.LIVING],
-  [CategoryCode.TRAVEL]: [StatusCode.LIVING],
-  [CategoryCode.COOKING]: [StatusCode.LIVING],
+export const CATEGORY_STATUS_MAP: Record<CategoryCode, StatusCode> = {
+  [CategoryCode.WEIGHT]: StatusCode.STR,
+  [CategoryCode.CLIMBING]: StatusCode.STR,
+  [CategoryCode.BALLGAME]: StatusCode.DEX,
+  [CategoryCode.ESPORTS]: StatusCode.DEX,
+  [CategoryCode.JOGGING]: StatusCode.DEX,
+  [CategoryCode.READING]: StatusCode.INT,
+  [CategoryCode.STUDY]: StatusCode.INT,
+  [CategoryCode.IT]: StatusCode.INT,
+  [CategoryCode.BEAUTY]: StatusCode.CHARM,
+  [CategoryCode.MUSIC]: StatusCode.CHARM,
+  [CategoryCode.INTERIOR]: StatusCode.LIVING,
+  [CategoryCode.TRAVEL]: StatusCode.LIVING,
+  [CategoryCode.COOKING]: StatusCode.LIVING,
 };

--- a/Client/src/utility/category.ts
+++ b/Client/src/utility/category.ts
@@ -8,23 +8,10 @@ import itIcon from '../assets/icons/it.png';
 import joggingIcon from '../assets/icons/jogging.png';
 import musicIcon from '../assets/icons/music.png';
 import readingIcon from '../assets/icons/reading.png';
-import CharmIcon from '../assets/icons/status-charm.png';
-import intelligenceIcon from '../assets/icons/status-intelligence.png';
-import livingIcon from '../assets/icons/status-living.png';
-import speedIcon from '../assets/icons/status-speed.png';
-import strengthIcon from '../assets/icons/status-strength.png';
 import studyIcon from '../assets/icons/study.png';
 import travelIcon from '../assets/icons/travel.png';
 import weightIcon from '../assets/icons/weight.png';
 import { CategoryCode, StatusCode } from '../api/category';
-
-export const STATUS_ICON: Record<StatusCode, string> = {
-  [StatusCode.STR]: strengthIcon,
-  [StatusCode.DEX]: speedIcon,
-  [StatusCode.INT]: intelligenceIcon,
-  [StatusCode.CHARM]: CharmIcon,
-  [StatusCode.LIVING]: livingIcon,
-};
 
 export const CATEGORY_ICON: Record<CategoryCode, string> = {
   [CategoryCode.WEIGHT]: weightIcon,
@@ -40,4 +27,36 @@ export const CATEGORY_ICON: Record<CategoryCode, string> = {
   [CategoryCode.INTERIOR]: interiorIcon,
   [CategoryCode.TRAVEL]: travelIcon,
   [CategoryCode.COOKING]: cookingIcon,
+};
+
+export const CATEGORY_NAME: Record<CategoryCode, string> = {
+  [CategoryCode.WEIGHT]: '헬스',
+  [CategoryCode.CLIMBING]: '등산',
+  [CategoryCode.BALLGAME]: '구기종목',
+  [CategoryCode.ESPORTS]: 'e스포츠',
+  [CategoryCode.JOGGING]: '조깅',
+  [CategoryCode.READING]: '독서',
+  [CategoryCode.STUDY]: '공부',
+  [CategoryCode.IT]: 'IT',
+  [CategoryCode.BEAUTY]: '미용',
+  [CategoryCode.MUSIC]: '음악',
+  [CategoryCode.INTERIOR]: '인테리어',
+  [CategoryCode.TRAVEL]: '여행',
+  [CategoryCode.COOKING]: '요리',
+};
+
+export const CATEGORY_STATUS_MAP: Record<CategoryCode, StatusCode[]> = {
+  [CategoryCode.WEIGHT]: [StatusCode.STR],
+  [CategoryCode.CLIMBING]: [StatusCode.STR],
+  [CategoryCode.BALLGAME]: [StatusCode.DEX],
+  [CategoryCode.ESPORTS]: [StatusCode.DEX],
+  [CategoryCode.JOGGING]: [StatusCode.DEX],
+  [CategoryCode.READING]: [StatusCode.INT],
+  [CategoryCode.STUDY]: [StatusCode.INT],
+  [CategoryCode.IT]: [StatusCode.INT],
+  [CategoryCode.BEAUTY]: [StatusCode.CHARM],
+  [CategoryCode.MUSIC]: [StatusCode.CHARM],
+  [CategoryCode.INTERIOR]: [StatusCode.LIVING],
+  [CategoryCode.TRAVEL]: [StatusCode.LIVING],
+  [CategoryCode.COOKING]: [StatusCode.LIVING],
 };

--- a/Client/src/utility/status.ts
+++ b/Client/src/utility/status.ts
@@ -1,0 +1,38 @@
+import { StatusCode, CategoryCode } from '../api/category';
+import CharmIcon from '../assets/icons/status-charm.png';
+import intelligenceIcon from '../assets/icons/status-intelligence.png';
+import livingIcon from '../assets/icons/status-living.png';
+import speedIcon from '../assets/icons/status-speed.png';
+import strengthIcon from '../assets/icons/status-strength.png';
+
+export const STATUS_ICON: Record<StatusCode, string> = {
+  [StatusCode.STR]: strengthIcon,
+  [StatusCode.DEX]: speedIcon,
+  [StatusCode.INT]: intelligenceIcon,
+  [StatusCode.CHARM]: CharmIcon,
+  [StatusCode.LIVING]: livingIcon,
+};
+
+export const STATUS_NAME: Record<StatusCode, string> = {
+  [StatusCode.STR]: '힘',
+  [StatusCode.DEX]: '민첩',
+  [StatusCode.INT]: '지능',
+  [StatusCode.CHARM]: '매력',
+  [StatusCode.LIVING]: '생활력',
+};
+
+export const STATUS_CATEGORY_MAP: Record<StatusCode, CategoryCode[]> = {
+  [StatusCode.STR]: [CategoryCode.WEIGHT, CategoryCode.CLIMBING],
+  [StatusCode.DEX]: [
+    CategoryCode.BALLGAME,
+    CategoryCode.ESPORTS,
+    CategoryCode.JOGGING,
+  ],
+  [StatusCode.INT]: [CategoryCode.READING, CategoryCode.STUDY, CategoryCode.IT],
+  [StatusCode.CHARM]: [CategoryCode.BEAUTY, CategoryCode.MUSIC],
+  [StatusCode.LIVING]: [
+    CategoryCode.INTERIOR,
+    CategoryCode.TRAVEL,
+    CategoryCode.COOKING,
+  ],
+};


### PR DESCRIPTION
API 응답 데이터에서는 코드 값만 받아 그 코드에 해당하는 이름, 아이콘 등의 정보는 프론트에서 매핑해서 쓸 수 있도록 작성했습니다.  

https://github.com/codestates-seb/seb45_main_022/blob/b15981aa4c4189e7f4c36b41dd203d475452b16e/Client/src/utility/status.ts#L16-L38

https://github.com/codestates-seb/seb45_main_022/blob/b15981aa4c4189e7f4c36b41dd203d475452b16e/Client/src/utility/category.ts#L32-L62

`uitility/icons.ts` 파일을 삭제하고 `utility/status.ts`와 `utility/category.ts` 생성했습니다.
스테이터스 코드, 카테고리 코드 값을 통해 아이콘을 가져올 수 있었던 것에 더해,
스테이터스/카테고리 이름, 스테이터스와 카테고리의 매핑 정보도 가져올 수 있도록 매핑 오브젝트를 작성했습니다.