### PR TITLE
✨ feat:feed report api 추가, email sender 추가

### DIFF
--- a/Server/src/main/java/com/codestatus/global/exception/ExceptionCode.java
+++ b/Server/src/main/java/com/codestatus/global/exception/ExceptionCode.java
@@ -21,7 +21,8 @@ public enum ExceptionCode {
     COMMENT_NOT_FOUND(404, "댓글을 찾을 수 없습니다."),
     FORBIDDEN_REQUEST(403, "해당 리소스에 접근이 불가능합니다."),
     STAT_NOT_FOUND(404, "스탯을 찾을 수 없습니다."),
-    LIKE_BAD_REQUEST(400, "자신의 게시물은 좋아요를 할 수 없습니다.");
+    LIKE_BAD_REQUEST(400, "자신의 게시물은 좋아요를 할 수 없습니다."),
+    DUPLICATE_REPORT_EXCEPTION(400, "신고는 한 번만 가능합니다.");
 
 //    NOT_IMPLEMENTATION(501, "해당 기능은 구현되지 않았습니다.");
 

--- a/Server/src/main/java/com/codestatus/global/mail/service/EmailService.java
+++ b/Server/src/main/java/com/codestatus/global/mail/service/EmailService.java
@@ -1,29 +1,20 @@
 package com.codestatus.global.mail.service;
 
 import com.codestatus.global.mail.entity.Email;
-import org.springframework.mail.SimpleMailMessage;
-import org.springframework.mail.javamail.JavaMailSender;
+import com.codestatus.global.utils.CustomMailSender;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.Random;
 
+@RequiredArgsConstructor
 @Service
 public class EmailService {
-    private final JavaMailSender javaMailSender;
-
-    public EmailService(JavaMailSender javaMailSender) {
-        this.javaMailSender = javaMailSender;
-    }
+    private final CustomMailSender customMailSender;
 
     public Email sendJoinCode(Email email) {
         String code = randomCodeGenerator(); // 인증번호 생성
-
-        SimpleMailMessage simpleMailMessage = new SimpleMailMessage();
-        simpleMailMessage.setTo(email.getAddress()); // 수신자 주소
-        simpleMailMessage.setSubject("CodeStatus 회원가입 인증 메일입니다."); // 메일 제목
-        simpleMailMessage.setText("인증번호는 " + code + " 입니다."); // 메일 본문
-        javaMailSender.send(simpleMailMessage); // 메일 전송
-
+        customMailSender.sendAuthenticationCode(code, email.getAddress());
         email.setCode(code); // 인증번호 저장
 
         return email;

--- a/Server/src/main/java/com/codestatus/global/report/controller/ReportController.java
+++ b/Server/src/main/java/com/codestatus/global/report/controller/ReportController.java
@@ -1,0 +1,32 @@
+package com.codestatus.global.report.controller;
+
+import com.codestatus.domain.feed.mapper.FeedMapper;
+import com.codestatus.domain.user.mapper.UserMapper;
+import com.codestatus.global.auth.dto.PrincipalDto;
+import com.codestatus.global.report.service.ReportFeedServiceImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/report")
+public class ReportController {
+    private final ReportFeedServiceImpl reportFeedService;
+    private final UserMapper userMapper;
+    private final FeedMapper feedMapper;
+
+    @PostMapping("/feed/{feedId}")
+    public ResponseEntity reportFeed(@PathVariable("feedId") long feedId, @AuthenticationPrincipal PrincipalDto principal) {
+        reportFeedService.report(
+                feedMapper.feedIdToFeed(feedId),
+                userMapper.userIdToUser(principal.getId())
+        );
+        return new ResponseEntity(HttpStatus.OK);
+    }
+}

--- a/Server/src/main/java/com/codestatus/global/report/entity/ReportFeed.java
+++ b/Server/src/main/java/com/codestatus/global/report/entity/ReportFeed.java
@@ -1,0 +1,29 @@
+package com.codestatus.global.report.entity;
+
+
+import com.codestatus.domain.feed.entity.Feed;
+import com.codestatus.domain.user.entity.User;
+import com.codestatus.global.audit.Auditable;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+
+@NoArgsConstructor
+@Getter
+@Setter
+@Entity(name = "report_feed")
+public class ReportFeed extends Auditable {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long reportId;
+
+    @ManyToOne
+    @JoinColumn(name = "reporter_id", updatable = false)
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "feed_id", updatable = false)
+    private Feed feed;
+}

--- a/Server/src/main/java/com/codestatus/global/report/reporitory/ReportFeedRepository.java
+++ b/Server/src/main/java/com/codestatus/global/report/reporitory/ReportFeedRepository.java
@@ -1,0 +1,13 @@
+package com.codestatus.global.report.reporitory;
+
+import com.codestatus.domain.feed.entity.Feed;
+import com.codestatus.domain.user.entity.User;
+import com.codestatus.global.report.entity.ReportFeed;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ReportFeedRepository extends JpaRepository<ReportFeed, Long> {
+    int countAllByFeed(Feed feed);
+    Optional<ReportFeed> findByFeedAndUser(Feed feed, User user);
+}

--- a/Server/src/main/java/com/codestatus/global/report/service/ReportFeedServiceImpl.java
+++ b/Server/src/main/java/com/codestatus/global/report/service/ReportFeedServiceImpl.java
@@ -1,0 +1,51 @@
+package com.codestatus.global.report.service;
+
+import com.codestatus.domain.feed.entity.Feed;
+import com.codestatus.domain.feed.service.FeedService;
+import com.codestatus.domain.user.entity.User;
+import com.codestatus.global.exception.BusinessLogicException;
+import com.codestatus.global.exception.ExceptionCode;
+import com.codestatus.global.report.entity.ReportFeed;
+import com.codestatus.global.report.reporitory.ReportFeedRepository;
+import com.codestatus.global.utils.CustomMailSender;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class ReportFeedServiceImpl implements ReportService<Feed>{
+    @Value("${report.feed-alarm-count}")
+    int feedAlarmCount;
+
+    private final ReportFeedRepository reportFeedRepository;
+    private final CustomMailSender customMailSender;
+    private final FeedService feedService;
+
+    @Override
+    public void report(Feed targetFeed, User user) {
+        targetFeed = feedService.findVerifiedFeed(targetFeed.getFeedId());
+
+        Optional<ReportFeed> optionalReportFeed = reportFeedRepository.findByFeedAndUser(targetFeed, user);
+        if (optionalReportFeed.isPresent()) throw new BusinessLogicException(ExceptionCode.DUPLICATE_REPORT_EXCEPTION);
+
+        ReportFeed reportFeed = new ReportFeed();
+        reportFeed.setFeed(targetFeed);
+        reportFeed.setUser(user);
+        reportFeedRepository.save(reportFeed);
+
+        sendReportAlarm(targetFeed);
+    }
+
+    @Override
+    public void sendReportAlarm(Feed targetFeed) {
+        int reportCount = reportFeedRepository.countAllByFeed(targetFeed);
+        if (reportCount >= feedAlarmCount) {
+            customMailSender.sendReportAlarm(targetFeed.getFeedId(), targetFeed.getUser().getNickName(), "피드");
+        }
+    }
+}

--- a/Server/src/main/java/com/codestatus/global/report/service/ReportService.java
+++ b/Server/src/main/java/com/codestatus/global/report/service/ReportService.java
@@ -1,0 +1,8 @@
+package com.codestatus.global.report.service;
+
+import com.codestatus.domain.user.entity.User;
+
+public interface ReportService<T> {
+    void report(T targetEntity, User user);
+    void sendReportAlarm(T targetEntity);
+}

--- a/Server/src/main/java/com/codestatus/global/utils/CustomMailSender.java
+++ b/Server/src/main/java/com/codestatus/global/utils/CustomMailSender.java
@@ -1,0 +1,37 @@
+package com.codestatus.global.utils;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class CustomMailSender {
+    @Value("${mail.username}")
+    private String sender;
+
+    private final JavaMailSender javaMailSender;
+
+    public void sendAuthenticationCode(String code, String sendTo){
+        String subject = "CodeStatus 회원가입 인증 메일입니다."; // 메일 제목
+        String text = "인증번호는 " + code + " 입니다."; // 메일 본문
+
+        sendMail(sendTo, subject, text);
+    }
+
+    public void sendReportAlarm(long targetId, String target, String type){
+        String subject = type + " " + targetId + " 누적 신고";
+        String text = type + " id: " + targetId + " 대상: "+ target + " 누적 신고";
+
+        sendMail(sender, subject, text);
+    }
+    private void sendMail(String sendTo, String subject, String text){
+        SimpleMailMessage simpleMailMessage = new SimpleMailMessage();
+        simpleMailMessage.setTo(sendTo);
+        simpleMailMessage.setSubject(subject);
+        simpleMailMessage.setText(text);
+        javaMailSender.send(simpleMailMessage);
+    }
+}

--- a/Server/src/main/resources/application-server.yml
+++ b/Server/src/main/resources/application-server.yml
@@ -73,3 +73,6 @@ jwt:
 exp:
   attendance-exp: 10
   like-exp: 10
+
+report:
+  feed-alarm-count: 5


### PR DESCRIPTION
✨ feat: feed report api 추가
- feed를 신고할 수 있는 기능을 추가하였습니다.
- 각 피드 별로 사람 당 한 번만 신고가 가능하고 N회 누적 신고 시 관리자에게 이메일을 보냅니다.

✨ feat: email sender 추가
- 회원 가입 시 사용하는 email sender와 신고 누적 시 사용하는 email sender의 공통 기능을 추상화 하였습니다.