### PR TITLE
♻️ refactor: 일일 출석체크 기능 분리

### DIFF
--- a/Server/src/main/java/com/codestatus/domain/attendance/controller/AttendanceController.java
+++ b/Server/src/main/java/com/codestatus/domain/attendance/controller/AttendanceController.java
@@ -1,0 +1,41 @@
+package com.codestatus.domain.attendance.controller;
+
+import com.codestatus.domain.attendance.dto.AttendanceDto;
+import com.codestatus.domain.attendance.entity.Attendance;
+import com.codestatus.domain.attendance.mapper.AttendanceMapper;
+import com.codestatus.domain.attendance.service.AttendanceService;
+import com.codestatus.global.auth.dto.PrincipalDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+
+@RequiredArgsConstructor
+@Validated
+@RestController
+@RequestMapping("/attendance")
+public class AttendanceController {
+    private final AttendanceService attendanceService;
+    private final AttendanceMapper attendanceMapper;
+
+    // 출석체크 컨트롤러
+    @PostMapping("/{chosenStat}")
+    public ResponseEntity checkAttendance(@PathVariable @Min(1) @Max(5) int chosenStat,
+                                          @AuthenticationPrincipal PrincipalDto principal) {
+        AttendanceDto attendanceDto = AttendanceDto.builder()
+                .statId(chosenStat)
+                .userId(principal.getId())
+                .build();
+        Attendance attendance = attendanceMapper.dtoToEntity(attendanceDto);
+        attendanceService.checkAttendance(attendance); // 출석체크 메서드 호출
+        return ResponseEntity.status(HttpStatus.OK).body("attendance check success"); // 출석체크 성공 메시지 반환
+    }
+}

--- a/Server/src/main/java/com/codestatus/domain/attendance/dto/AttendanceDto.java
+++ b/Server/src/main/java/com/codestatus/domain/attendance/dto/AttendanceDto.java
@@ -1,0 +1,11 @@
+package com.codestatus.domain.attendance.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AttendanceDto {
+    private int statId;
+    private Long userId;
+}

--- a/Server/src/main/java/com/codestatus/domain/attendance/entity/Attendance.java
+++ b/Server/src/main/java/com/codestatus/domain/attendance/entity/Attendance.java
@@ -1,0 +1,23 @@
+package com.codestatus.domain.attendance.entity;
+
+import com.codestatus.global.audit.Auditable;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+public class Attendance extends Auditable {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long attendanceId;
+
+    @Column(nullable = false, unique = true)
+    private Long userId;
+
+    @Column
+    private int statId;
+}

--- a/Server/src/main/java/com/codestatus/domain/attendance/mapper/AttendanceMapper.java
+++ b/Server/src/main/java/com/codestatus/domain/attendance/mapper/AttendanceMapper.java
@@ -1,0 +1,15 @@
+package com.codestatus.domain.attendance.mapper;
+
+import com.codestatus.domain.attendance.dto.AttendanceDto;
+import com.codestatus.domain.attendance.entity.Attendance;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AttendanceMapper {
+    public Attendance dtoToEntity(AttendanceDto attendanceDto) {
+        Attendance attendance = new Attendance();
+        attendance.setUserId(attendanceDto.getUserId());
+        attendance.setStatId(attendanceDto.getStatId());
+        return attendance;
+    }
+}

--- a/Server/src/main/java/com/codestatus/domain/attendance/repository/AttendanceRepository.java
+++ b/Server/src/main/java/com/codestatus/domain/attendance/repository/AttendanceRepository.java
@@ -1,0 +1,8 @@
+package com.codestatus.domain.attendance.repository;
+
+import com.codestatus.domain.attendance.entity.Attendance;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
+
+}

--- a/Server/src/main/java/com/codestatus/domain/attendance/service/AttendanceService.java
+++ b/Server/src/main/java/com/codestatus/domain/attendance/service/AttendanceService.java
@@ -1,0 +1,83 @@
+package com.codestatus.domain.attendance.service;
+
+import com.codestatus.domain.attendance.entity.Attendance;
+import com.codestatus.domain.attendance.repository.AttendanceRepository;
+import com.codestatus.domain.user.entity.User;
+import com.codestatus.domain.user.repository.ExpTableRepository;
+import com.codestatus.domain.user.repository.UserRepository;
+import com.codestatus.global.exception.BusinessLogicException;
+import com.codestatus.global.exception.ExceptionCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AttendanceService {
+    @Value("${exp.attendance-exp}")
+    private int attendanceExp;
+    private final UserRepository userRepository;
+    private final ExpTableRepository expTableRepository;
+    private final AttendanceRepository attendanceRepository;
+
+    public void checkAttendance(Attendance attendance) {
+        User user = findUser(attendance.getUserId()); // 유저 검색(유저가 없거나, DELETE 상태인 유저인 경우 예외)
+        int chosenStat = attendance.getStatId() - 1; // chosenStat: 1(str), 2(dex), 3(int), 4(charm), 5(vitality)
+
+        try {
+            attendanceRepository.save(attendance); // attendance 테이블에 user_id, stat_id 저장 try
+        } catch (DataIntegrityViolationException e) { // 테이블에 user_id(unique)가 이미 존재 한다면 예외 발생
+            throw new BusinessLogicException(ExceptionCode.USER_ALREADY_CHECKED_ATTENDANCE);
+        }
+
+        user.getStatuses().get(chosenStat).setStatExp(user.getStatuses().get(chosenStat).getStatExp() + attendanceExp); // 선택한 stat 경험치 증가
+        levelUpCheck(user, chosenStat); // 레벨업 체크
+
+        userRepository.save(user); // 유저 정보 저장
+    }
+
+    public User findUser(long loginId) {
+        User user = userRepository.findById(loginId).orElseThrow(() -> new BusinessLogicException(ExceptionCode.USER_NOT_FOUND));
+        if (user.getUserStatus().equals(User.UserStatus.USER_DELETE)) {
+            throw new BusinessLogicException(ExceptionCode.USER_IS_DELETED);
+        }
+        return user;
+    }
+
+    private void levelUpCheck(User user, int chosenStat) { // chooseStat: 1(str), 2(dex), 3(int), 4(charm), 5(vitality)
+        int maxLevel = 100; // 최대 레벨
+        int currentLevel = user.getStatuses().get(chosenStat).getStatLevel(); // 현재 레벨
+
+        if (currentLevel >= maxLevel) { // 현재 레벨이 최대 레벨이라면 레벨업 불가
+            return;
+        }
+
+        int currentExp = user.getStatuses().get(chosenStat).getStatExp(); // 현재 경험치
+        int requiredExp = expTableRepository.findById((long) currentLevel).get().getRequired(); // 필요 경험치
+
+        if (currentExp >= requiredExp) { // 현재 경험치가 필요 경험치보다 많다면 레벨업
+            currentLevel += 1; // 레벨업
+            user.getStatuses().get(chosenStat).setStatLevel(currentLevel); // 레벨 저장
+            currentExp -= requiredExp; // 현재 경험치에서 필요 경험치 차감
+            user.getStatuses().get(chosenStat).setStatExp(currentExp); // 경험치 차감
+        }
+
+        // 현재 레벨에서 다음 레벨까지 필요한 경험치 = 다음 레벨까지 필요한 경험치 - 현재 레벨까지 필요한 경험치
+        int nextLevelRequiredExp = expTableRepository.findById((long) (currentLevel)).get().getRequired() - currentExp;
+        user.getStatuses().get(chosenStat).setRequiredExp(nextLevelRequiredExp); // 다음 레벨까지 필요한 경험치 저장
+
+        userRepository.save(user); // 유저 정보 저장
+    }
+
+    @Scheduled(cron = "0 0 0 * * ?", zone = "Asia/Seoul") // cron = "0 0 0 * * ?", zone = "Asia/Seoul" <- 매일 자정마다 실행
+    public void cleanAttendanceTable() { // 다음날 출석체크를 위해 attendance 테이블 비우기
+        attendanceRepository.deleteAll();
+    }
+}
+
+
+

--- a/Server/src/main/java/com/codestatus/domain/user/controller/UserController.java
+++ b/Server/src/main/java/com/codestatus/domain/user/controller/UserController.java
@@ -3,9 +3,9 @@ package com.codestatus.domain.user.controller;
 import com.codestatus.domain.user.dto.UserDto;
 import com.codestatus.domain.user.entity.User;
 import com.codestatus.domain.user.mapper.UserMapper;
-import com.codestatus.domain.user.service.LevelServiceImpl;
 import com.codestatus.domain.user.service.UserServiceImpl;
 import com.codestatus.global.auth.dto.PrincipalDto;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -18,18 +18,12 @@ import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 
 @Validated
+@RequiredArgsConstructor
 @RestController
 @RequestMapping("/user")
 public class UserController {
     private final UserMapper userMapper;
     private final UserServiceImpl service;
-    private final LevelServiceImpl levelServiceImpl;
-
-    public UserController(UserMapper userMapper, UserServiceImpl service, LevelServiceImpl levelServiceImpl) {
-        this.userMapper = userMapper;
-        this.service = service;
-        this.levelServiceImpl = levelServiceImpl;
-    }
 
     // 유저 가입 컨트롤러
     @PostMapping("/signup")
@@ -63,14 +57,6 @@ public class UserController {
         User user = userMapper.userPatchPasswordToUser(requestBody); // PatchDto -> Entity
         service.updatePassword(user, principal.getId()); // 유저 비밀번호 수정 메서드 호출
         return ResponseEntity.status(HttpStatus.OK).body("password patch success"); // 비밀번호 수정 성공 메시지 반환
-    }
-
-    // 출석체크 컨트롤러
-    @PostMapping("/mypage/attendance/{chosenStat}")
-    public ResponseEntity checkAttendance(@PathVariable @Min(1) @Max(5) int chosenStat,
-                                          @AuthenticationPrincipal PrincipalDto principal) {
-        levelServiceImpl.checkAttendance(chosenStat - 1, principal.getId()); // 출석체크 메서드 호출
-        return ResponseEntity.status(HttpStatus.OK).body("attendance check success"); // 출석체크 성공 메시지 반환
     }
 
     // 프로필 이미지 업로드

--- a/Server/src/main/java/com/codestatus/domain/user/service/LevelServiceImpl.java
+++ b/Server/src/main/java/com/codestatus/domain/user/service/LevelServiceImpl.java
@@ -3,39 +3,16 @@ package com.codestatus.domain.user.service;
 import com.codestatus.domain.user.entity.User;
 import com.codestatus.domain.user.repository.ExpTableRepository;
 import com.codestatus.domain.user.repository.UserRepository;
-import com.codestatus.global.exception.BusinessLogicException;
-import com.codestatus.global.exception.ExceptionCode;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Transactional
 @Service
 @RequiredArgsConstructor
 public class LevelServiceImpl implements LevelService {
-    @Value("${exp.attendance-exp}")
-    private int attendanceExp;
     private final UserRepository userRepository;
     private final ExpTableRepository expTableRepository;
-    private final UserService userService;
-
-    // 출석체크
-    public void checkAttendance(int chosenStat, long loginId) { // chosenStat: 1(str), 2(dex), 3(int), 4(charm), 5(vitality)
-        User findUser = userService.findVerifiedUser(loginId); // 유저 검증 메서드(유저가 존재하지 않으면 예외처리)
-
-        if(findUser.isAttendance()) { // 이미 출석체크를 했다면 예외 발생
-            throw new BusinessLogicException(ExceptionCode.USER_ALREADY_CHECKED_ATTENDANCE);
-        }
-
-        findUser.getStatuses().get(chosenStat).setStatExp(findUser.getStatuses().get(chosenStat).getStatExp() + attendanceExp); // 선택한 stat 경험치 증가
-        levelUpCheck(findUser, chosenStat); // 레벨업 체크
-        findUser.setAttendance(true); // 출석체크 상태를 true로 변경
-        userRepository.save(findUser);
-    }
 
     @Override
     public void gainExp(User user, int exp, int statId) {
@@ -43,21 +20,6 @@ public class LevelServiceImpl implements LevelService {
                 user.getStatuses().get(statId-1).getStatExp() + exp
         );
         levelUpCheck(user, statId-1);
-    }
-
-    /*
-    만약 출석체크 상태를 변경해야 할 유저가 많아진다면
-    서버에 부담이 되지 않을까?
-     */
-
-    // 유저 상태가 USER_ACTIVE인 유저와 출석체크 상태가 true인 유저만 변경(매일 자정마다 실행)
-    @Scheduled(cron = "0 0 0 * * ?", zone = "Asia/Seoul") // cron = "0 0 0 * * ?", zone = "Asia/Seoul" <- 매일 자정마다 실행
-    public void updateAttendance() {
-        List<User> users = userRepository.findAllByUserStatusAndAttendance(User.UserStatus.USER_ACTIVE, true); // 유저 상태가 USER_ACTIVE인 유저와 출석체크 상태가 true인 유저만 조회
-        for (User user : users) { // 출석체크 상태를 false로 변경
-            user.setAttendance(false);
-        }
-        userRepository.saveAll(users);
     }
 
     private void levelUpCheck(User user, int chosenStat) { // chooseStat: 1(str), 2(dex), 3(int), 4(charm), 5(vitality)
@@ -77,7 +39,7 @@ public class LevelServiceImpl implements LevelService {
             user.getStatuses().get(chosenStat).setStatExp(currentExp); // 경험치 차감
         }
 
-        // 현재 레벨에서 다음 레벨까지 필요한 경험치 = 다음 레벨까지 필요한 경험치 - 현재 레벨까지 필요한 경험치 (백분률로 저장)
+        // 현재 레벨에서 다음 레벨까지 필요한 경험치 = 다음 레벨까지 필요한 경험치 - 현재 레벨까지 필요한 경험치
         int nextLevelRequiredExp = expTableRepository.findById((long) (currentLevel)).get().getRequired() - currentExp;
         user.getStatuses().get(chosenStat).setRequiredExp(nextLevelRequiredExp); // 다음 레벨까지 필요한 경험치 저장
 


### PR DESCRIPTION
- UserService 가 가지고 있던 출석체크 기능을 분리해 별도의 service 생성
- attendance 테이블을 추가(userId = unique)
- 출석체크 api 호출시 user Id 를 attendance  테이블에 insert 를 시도하고 이때 userId 가 이미 존재한다면 예외처리
- 스케쥴링으로 매일 자정마다 attendance 테이블의 데이터 일괄 삭제(deleteAll())

- 스탯별 경험치 상승 및 레벨 상승 테스트 완료
- 2회 호출시 예외 발생 확인