### PR TITLE
✨ feat: 뒤로 가기 버튼 컴포넌트로 캡슐화 및 Map & Feed 페이지에 적용

### DIFF
--- a/Client/src/components/common/BackButton.tsx
+++ b/Client/src/components/common/BackButton.tsx
@@ -1,0 +1,64 @@
+import { useNavigate } from 'react-router';
+import { CategoryCode } from '../../api/category';
+import backButton from '../../assets/common/back-button.png';
+
+interface Props {
+  categoryCode: CategoryCode;
+}
+
+export function BackButton({ categoryCode }: Props) {
+  const nav = useNavigate();
+
+  const handleBackClick = () => {
+    if (categoryCode > 1) {
+      nav(`/feed/${categoryCode - 1}`);
+    }
+  };
+
+  return (
+    <img
+      src={backButton}
+      alt="back"
+      onClick={handleBackClick}
+      width={48}
+      height={36}
+      className="cursor-pointer"
+    />
+  );
+}
+
+export function FrontButton({ categoryCode }: Props) {
+  const nav = useNavigate();
+
+  const handleFrontClick = () => {
+    if (categoryCode < 13) {
+      nav(`/feed/${categoryCode + 1}`);
+    }
+  };
+
+  return (
+    <img
+      src={backButton}
+      alt="front"
+      onClick={handleFrontClick}
+      width={48}
+      height={36}
+      className="rotate-180 cursor-pointer"
+    />
+  );
+}
+
+export function ReturnToMainButton() {
+  const nav = useNavigate();
+
+  return (
+    <img
+      src={backButton}
+      alt="MainButton"
+      onClick={() => nav('/main/status')}
+      width={48}
+      height={36}
+      className="cursor-pointer"
+    />
+  );
+}

--- a/Client/src/components/feed/Header.tsx
+++ b/Client/src/components/feed/Header.tsx
@@ -29,7 +29,7 @@ const Header = ({ categoryCode }: Props) => {
       {/* 아이콘, 카테고리 이름 */}
       <div
         className="w-[250px] flex justify-between items-center cursor-pointer"
-        onClick={() => nav(-1)}
+        onClick={() => nav(`/map/${CATEGORY_STATUS_MAP[categoryCode]}`)}
       >
         <img
           className="w-[50px] h-[50px]"

--- a/Client/src/pages/FeedPage.tsx
+++ b/Client/src/pages/FeedPage.tsx
@@ -2,11 +2,12 @@ import Backdrop from '../components/common/Backdrop';
 import Header from '../components/feed/Header';
 import board from '../assets/feed/board.png';
 import Main from '../components/feed/Main';
-
 import { Outlet, useParams } from 'react-router';
 import useFeedList from '../hooks/useFeedList';
 import LoadingBar from '../components/common/LoadingBar';
 import { Feed } from '../api/feed';
+import { BackButton } from '../components/common/BackButton';
+import { FrontButton } from '../components/common/BackButton';
 
 const FeedPage = () => {
   const { categoryCodeParam } = useParams();
@@ -43,9 +44,15 @@ const FeedPage = () => {
   return (
     <div className="flex flex-col justify-center items-center w-screen h-screen bg-feed bg-center bg-cover">
       <Backdrop>
-        <div className=" w-[1080px] h-[720px] p-[42px]" style={sectionStyle}>
-          <Header categoryCode={categoryCode} />
-          <Main feedList={feedList} categoryCode={categoryCode} />
+        <div className="flex flex-col justify-between items-center gap-8 mt-8">
+          <div className=" w-[1080px] h-[720px] p-[42px]" style={sectionStyle}>
+            <Header categoryCode={categoryCode} />
+            <Main feedList={feedList} categoryCode={categoryCode} />
+          </div>
+          <div className="flex gap-[900px]">
+            {categoryCode !== 1 && <BackButton categoryCode={categoryCode} />}
+            {categoryCode !== 13 && <FrontButton categoryCode={categoryCode} />}
+          </div>
         </div>
       </Backdrop>
       <Outlet />

--- a/Client/src/pages/MapPage.tsx
+++ b/Client/src/pages/MapPage.tsx
@@ -5,14 +5,12 @@ import ModalFrame from '../components/common/ModalFrame';
 import ServerList from '../components/map/ServerList';
 import { STATUS_CATEGORY_MAP } from '../utility/status';
 import { StatusCode, CategoryCode } from '../api/category';
-import { useNavigate } from 'react-router';
-import backButton from '../assets/common/back-button.png';
+import { ReturnToMainButton } from '../components/common/BackButton';
 
 const MapPage = () => {
   const [categoryList, setCategoryList] = useState<CategoryCode[]>([]);
   const { statusCodeParam } = useParams<{ statusCodeParam: string }>();
   const statusCode: StatusCode = Number(statusCodeParam);
-  const nav = useNavigate();
 
   useEffect(() => {
     const fetchCategoryData = async () => {
@@ -30,14 +28,8 @@ const MapPage = () => {
       <Backdrop>
         <ModalFrame width={1020} height={680}>
           <div className="flex w-full h-full relative">
-            <div className="mt-[17px] ml-[90px] absolute cursor-pointer">
-              <img
-                src={backButton}
-                alt="back"
-                onClick={() => nav(-1)}
-                width={48}
-                height={36}
-              />
+            <div className="mt-[17px] ml-[90px] absolute">
+              <ReturnToMainButton />
             </div>
             <div className="w-full h-[80px] flex justify-center items-center text-4xl mb-4">
               Servers


### PR DESCRIPTION
https://github.com/codestates-seb/seb45_main_022/assets/85780501/5c04ce6b-5e8d-424b-a2c1-9255b5c9738d

<br>

- Map 페이지에서 적용하던 뒤로 가기 버튼을 컴포넌트로 캡슐화하였습니다.
- 추가로 앞으로 가기 버튼도 추가하여, 페이지 간 이동을 원활하게 하였습니다.
- Map 페이지에서 뒤로 가기 버튼을 클릭 시, Main Status 페이지로 이동하게 변경하였습니다.
- Feed 페이지에서 뒤로 가기 & 앞으로 가기 버튼 클릭 시, 카테고리 페이지끼리 이동하도록 하였습니다.