### PR TITLE
✨ feat: 카테고리 내 특정 키워드의 해쉬태그를 포함한 feed 검색 api 추가

### DIFF
--- a/Server/src/main/java/com/codestatus/domain/comment/command/CommentCommand.java
+++ b/Server/src/main/java/com/codestatus/domain/comment/command/CommentCommand.java
@@ -16,7 +16,7 @@ public class CommentCommand {
     private final CommentRepository commentRepository;
 
     public void deleteCommentAll(long userId){
-        List<Comment> commentList = commentRepository.findAllByUser_UserIdAndDeletedIsFalse(userId);
+        List<Comment> commentList = commentRepository.findAllByUserUserIdAndDeletedIsFalse(userId);
         deleteCommentAll(commentList);
     }
 

--- a/Server/src/main/java/com/codestatus/domain/comment/repository/CommentRepository.java
+++ b/Server/src/main/java/com/codestatus/domain/comment/repository/CommentRepository.java
@@ -11,7 +11,5 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 //    @Query(nativeQuery = true, value = "SELECT * FROM comment as c WHERE c.comment_id=:commentId AND c.deleted=:deleted")
     Optional<Comment> findCommentByCommentIdAndDeleted(long commentId, boolean deleted);
 
-    List<Comment> findAllByUser_UserIdAndDeletedIsFalse(long userId);
-
-    List<Comment> findAllByFeed_FeedIdAndDeletedIsFalse(long feedId);
+    List<Comment> findAllByUserUserIdAndDeletedIsFalse(long userId);
 }

--- a/Server/src/main/java/com/codestatus/domain/feed/command/FeedCommand.java
+++ b/Server/src/main/java/com/codestatus/domain/feed/command/FeedCommand.java
@@ -31,7 +31,7 @@ public class FeedCommand {
     }
 
     public void deleteFeedAll(long userId) {
-        List<Feed> feedList = feedRepository.findAllByUser_UserIdAndDeletedIsFalse(userId);
+        List<Feed> feedList = feedRepository.findAllByUserUserIdAndDeletedIsFalse(userId);
         feedList.forEach(feed -> feed.setDeleted(true));
         feedRepository.saveAll(feedList);
     }

--- a/Server/src/main/java/com/codestatus/domain/feed/controller/FeedController.java
+++ b/Server/src/main/java/com/codestatus/domain/feed/controller/FeedController.java
@@ -108,7 +108,7 @@ public class FeedController {
     }
 
     //카테고리 내 피드 본문 검색
-    @GetMapping("/findByBody/{categoryId}")
+    @GetMapping("/find/body/{categoryId}")
     public ResponseEntity getFeedsByBodyAndCategory(@PathVariable("categoryId") @Min(0) @Max(13) long categoryId,
                                                     @RequestParam int page,
                                          @RequestParam int size,
@@ -122,7 +122,7 @@ public class FeedController {
     }
 
     //카테고리 내 유저 닉네임으로 피드 검색
-    @GetMapping("/findByUser/{categoryId}")
+    @GetMapping("/find/user/{categoryId}")
     public ResponseEntity getFeedsByUserAndCategory(@PathVariable("categoryId") @Min(1) @Max(13) long categoryId,
                                                     @RequestParam int page,
                                                     @RequestParam int size,
@@ -135,7 +135,7 @@ public class FeedController {
                         feedMapper.feedsToFeedResponseDtos(feeds), pageFeeds), HttpStatus.OK);
     }
     //HashTagID로 검색
-    @GetMapping("/findByHashTag/{categoryId}")
+    @GetMapping("/find/hashTagId/{categoryId}")
     public ResponseEntity getFeedsByHashTagAndCategory(@PathVariable("categoryId") @Min(0) @Max(13) long categoryId,
                                                     @RequestParam int page,
                                                     @RequestParam int size,
@@ -143,6 +143,18 @@ public class FeedController {
         Page<Feed> pageFeeds = feedServiceImpl.findFeedByHashTagAndCategory(categoryId, hashTagId, page-1, size);
         List<Feed> feeds = pageFeeds.getContent();
 
+        return new ResponseEntity<>(
+                new MultiResponseDto<>(
+                        feedMapper.feedsToFeedResponseDtos(feeds), pageFeeds), HttpStatus.OK);
+    }
+
+    @GetMapping("/find/hashTag/{categoryId}")
+    public ResponseEntity getFeedsByHashTagBody(@PathVariable("categoryId") @Min(0) @Max(13) long categoryId,
+                                                @RequestParam int page,
+                                                @RequestParam int size,
+                                                @RequestParam String body) {
+        Page<Feed> pageFeeds = feedServiceImpl.findFeedByHashTagBody(categoryId, body, page - 1, size);
+        List<Feed> feeds = pageFeeds.getContent();
         return new ResponseEntity<>(
                 new MultiResponseDto<>(
                         feedMapper.feedsToFeedResponseDtos(feeds), pageFeeds), HttpStatus.OK);

--- a/Server/src/main/java/com/codestatus/domain/feed/repository/FeedRepository.java
+++ b/Server/src/main/java/com/codestatus/domain/feed/repository/FeedRepository.java
@@ -24,6 +24,8 @@ public interface FeedRepository extends JpaRepository <Feed, Long> {
 
     Page<Feed> findByCategory_CategoryIdAndFeedHashTags_HashTag_HashTagId(long categoryId, long hashTagId, Pageable pageable);
 
+    Page<Feed> findByCategory_CategoryIdAndDeletedIsFalseAndFeedHashTags_HashTag_BodyContaining(long categoryId, String body, Pageable pageable);
+
     @Query("SELECT f FROM Feed f WHERE f.category.categoryId = :categoryId AND f.deleted = false ")
     Page<Feed> findAllFeedByCategory(long categoryId, Pageable pageable);
 

--- a/Server/src/main/java/com/codestatus/domain/feed/repository/FeedRepository.java
+++ b/Server/src/main/java/com/codestatus/domain/feed/repository/FeedRepository.java
@@ -22,9 +22,9 @@ public interface FeedRepository extends JpaRepository <Feed, Long> {
     @Query("SELECT f FROM Feed f WHERE f.category.categoryId = :categoryId AND f.user.nickname LIKE %:user% AND f.deleted = false ")
     Page<Feed> findByUserAndDeleted(@Param("categoryId")long categoryId, @Param("user") String user,  Pageable pageable);
 
-    Page<Feed> findByCategoryCategoryIdAndFeedHashTags_HashTag_HashTagId(long categoryId, long hashTagId, Pageable pageable);
+    Page<Feed> findByCategoryCategoryIdAndFeedHashTagsHashTagHashTagId(long categoryId, long hashTagId, Pageable pageable);
 
-    Page<Feed> findByCategoryCategoryIdAndDeletedIsFalseAndFeedHashTags_HashTag_BodyContaining(long categoryId, String body, Pageable pageable);
+    Page<Feed> findByCategoryCategoryIdAndDeletedIsFalseAndFeedHashTagsHashTagBodyContaining(long categoryId, String body, Pageable pageable);
 
     @Query("SELECT f FROM Feed f WHERE f.category.categoryId = :categoryId AND f.deleted = false ")
     Page<Feed> findAllFeedByCategory(long categoryId, Pageable pageable);

--- a/Server/src/main/java/com/codestatus/domain/feed/repository/FeedRepository.java
+++ b/Server/src/main/java/com/codestatus/domain/feed/repository/FeedRepository.java
@@ -22,22 +22,22 @@ public interface FeedRepository extends JpaRepository <Feed, Long> {
     @Query("SELECT f FROM Feed f WHERE f.category.categoryId = :categoryId AND f.user.nickname LIKE %:user% AND f.deleted = false ")
     Page<Feed> findByUserAndDeleted(@Param("categoryId")long categoryId, @Param("user") String user,  Pageable pageable);
 
-    Page<Feed> findByCategory_CategoryIdAndFeedHashTags_HashTag_HashTagId(long categoryId, long hashTagId, Pageable pageable);
+    Page<Feed> findByCategoryCategoryIdAndFeedHashTags_HashTag_HashTagId(long categoryId, long hashTagId, Pageable pageable);
 
-    Page<Feed> findByCategory_CategoryIdAndDeletedIsFalseAndFeedHashTags_HashTag_BodyContaining(long categoryId, String body, Pageable pageable);
+    Page<Feed> findByCategoryCategoryIdAndDeletedIsFalseAndFeedHashTags_HashTag_BodyContaining(long categoryId, String body, Pageable pageable);
 
     @Query("SELECT f FROM Feed f WHERE f.category.categoryId = :categoryId AND f.deleted = false ")
     Page<Feed> findAllFeedByCategory(long categoryId, Pageable pageable);
 
-    Page<Feed> findAllByCategory_CategoryIdAndBodyContainingAndDeletedIsFalse(long categoryId, String body, Pageable pageable);
+    Page<Feed> findAllByCategoryCategoryIdAndBodyContainingAndDeletedIsFalse(long categoryId, String body, Pageable pageable);
 
     Page<Feed> findAllByDeletedIsFalse(Pageable pageable);
 
     Page<Feed> findAllByDeletedIsFalseAndCategoryCategoryId(long categoryId, Pageable pageable);
 
-    List<Feed> findAllByUser_UserIdAndDeletedIsFalse(long userId);
+    List<Feed> findAllByUserUserIdAndDeletedIsFalse(long userId);
 
-    Page<Feed> findAllByUser_UserIdAndDeletedIsFalse(long userId, Pageable pageable);
+    Page<Feed> findAllByUserUserIdAndDeletedIsFalse(long userId, Pageable pageable);
 
     // 일주일 안에 작성된 피드를 likes 의 사이즈 순으로 정렬해서 조회
     @Query(nativeQuery = true,

--- a/Server/src/main/java/com/codestatus/domain/feed/service/FeedServiceImpl.java
+++ b/Server/src/main/java/com/codestatus/domain/feed/service/FeedServiceImpl.java
@@ -84,14 +84,14 @@ public class FeedServiceImpl implements FeedService {
     public Page<Feed> findFeedByHashTagAndCategory(long categoryId, long hashTagId, int page, int size) {
         Sort sort = Sort.by(Sort.Direction.DESC, "createdAt"); //최신순 정렬
         Pageable pageable = PageRequest.of(page, size, sort);
-        return feedRepository.findByCategoryCategoryIdAndFeedHashTags_HashTag_HashTagId(categoryId, hashTagId, pageable);
+        return feedRepository.findByCategoryCategoryIdAndFeedHashTagsHashTagHashTagId(categoryId, hashTagId, pageable);
     }
 
     @Transactional(readOnly = true)
     public Page<Feed> findFeedByHashTagBody(long categoryId, String body, int page, int size) {
         Sort sort = Sort.by(Sort.Direction.DESC, "createdAt");
         Pageable pageable = PageRequest.of(page, size, sort);
-        return feedRepository.findByCategoryCategoryIdAndDeletedIsFalseAndFeedHashTags_HashTag_BodyContaining(categoryId, body, pageable);
+        return feedRepository.findByCategoryCategoryIdAndDeletedIsFalseAndFeedHashTagsHashTagBodyContaining(categoryId, body, pageable);
     }
 
     //삭제되지않은 피드목록 조회

--- a/Server/src/main/java/com/codestatus/domain/feed/service/FeedServiceImpl.java
+++ b/Server/src/main/java/com/codestatus/domain/feed/service/FeedServiceImpl.java
@@ -68,7 +68,7 @@ public class FeedServiceImpl implements FeedService {
     public Page<Feed> findFeedByBodyAndCategory(long categoryId, String text, int page, int size) {
         Sort sort = Sort.by(Sort.Direction.DESC, "createdAt"); //최신순 정렬
         Pageable pageable = PageRequest.of(page, size, sort);
-        return feedRepository.findAllByCategory_CategoryIdAndBodyContainingAndDeletedIsFalse(categoryId, text, pageable);
+        return feedRepository.findAllByCategoryCategoryIdAndBodyContainingAndDeletedIsFalse(categoryId, text, pageable);
     }
 
     //(검색기능)텍스트 받아서 해당 카테고리 내에서 해당하는 유저가 쓴 피드목록 조회
@@ -84,14 +84,14 @@ public class FeedServiceImpl implements FeedService {
     public Page<Feed> findFeedByHashTagAndCategory(long categoryId, long hashTagId, int page, int size) {
         Sort sort = Sort.by(Sort.Direction.DESC, "createdAt"); //최신순 정렬
         Pageable pageable = PageRequest.of(page, size, sort);
-        return feedRepository.findByCategory_CategoryIdAndFeedHashTags_HashTag_HashTagId(categoryId, hashTagId, pageable);
+        return feedRepository.findByCategoryCategoryIdAndFeedHashTags_HashTag_HashTagId(categoryId, hashTagId, pageable);
     }
 
     @Transactional(readOnly = true)
     public Page<Feed> findFeedByHashTagBody(long categoryId, String body, int page, int size) {
         Sort sort = Sort.by(Sort.Direction.DESC, "createdAt");
         Pageable pageable = PageRequest.of(page, size, sort);
-        return feedRepository.findByCategory_CategoryIdAndDeletedIsFalseAndFeedHashTags_HashTag_BodyContaining(categoryId, body, pageable);
+        return feedRepository.findByCategoryCategoryIdAndDeletedIsFalseAndFeedHashTags_HashTag_BodyContaining(categoryId, body, pageable);
     }
 
     //삭제되지않은 피드목록 조회
@@ -129,7 +129,7 @@ public class FeedServiceImpl implements FeedService {
     public Page<Feed> myPost(long userId, int page, int size) {
         Sort sort = Sort.by(Sort.Direction.DESC, "createdAt"); //최신순 정렬
         Pageable pageable = PageRequest.of(page, size, sort);
-        return feedRepository.findAllByUser_UserIdAndDeletedIsFalse(userId, pageable);
+        return feedRepository.findAllByUserUserIdAndDeletedIsFalse(userId, pageable);
     }
 
     //db에서 완전 삭제가 아닌 deleted=true 로 수정

--- a/Server/src/main/java/com/codestatus/domain/feed/service/FeedServiceImpl.java
+++ b/Server/src/main/java/com/codestatus/domain/feed/service/FeedServiceImpl.java
@@ -87,6 +87,13 @@ public class FeedServiceImpl implements FeedService {
         return feedRepository.findByCategory_CategoryIdAndFeedHashTags_HashTag_HashTagId(categoryId, hashTagId, pageable);
     }
 
+    @Transactional(readOnly = true)
+    public Page<Feed> findFeedByHashTagBody(long categoryId, String body, int page, int size) {
+        Sort sort = Sort.by(Sort.Direction.DESC, "createdAt");
+        Pageable pageable = PageRequest.of(page, size, sort);
+        return feedRepository.findByCategory_CategoryIdAndDeletedIsFalseAndFeedHashTags_HashTag_BodyContaining(categoryId, body, pageable);
+    }
+
     //삭제되지않은 피드목록 조회
     @Transactional(readOnly = true)
     public Page<Feed> findAllFeedByDeleted(int page, int size) {


### PR DESCRIPTION
✨ feat: 카테고리 내 특정 키워드의 해쉬태그를 포함한 feed 검색 api 추가
- 검색 테스트 완료
- 삭제된 feed 제외 확인

🐛 fix: feed 검색 uri 수정
- feed 검색용 uri 통일감 있게 수정했습니다.
- /feed/find = 피드 본문 검색(카테고리 구분 없음)
- /feed/find/body/{categoryId} = 카테고리 내 본문으로 피드 검색
- /feed/find/user/{categoryId} = 카테고리 내 작성자로 피드 검색
- /feed/find/hashTag/{categoryId} = 카테고리 내 해쉬태그로 피드 검색
- /feed/find/hashTagId/{categoryId} = 카테고리 내 해쉬태그 id 로 피드 검색
- 변경한 uri 로 동작 확인 완료 했습니다.