### PR TITLE
✨ feat: 좋아요 여부 표시 기능 추가

### DIFF
--- a/Server/src/main/java/com/codestatus/domain/feed/controller/FeedController.java
+++ b/Server/src/main/java/com/codestatus/domain/feed/controller/FeedController.java
@@ -54,71 +54,82 @@ public class FeedController {
     @GetMapping("/{feedId}")
     public ResponseEntity getFeedByCategory(@PathVariable("feedId") long feedId) {
         Feed feed = feedServiceImpl.findEntity(feedId);
+        boolean isLike = feedServiceImpl.isLikeUser(feedId, feed.getUser().getUserId());
 
         FeedResponseDto feedResponseDto =
-                feedMapper.feedToFeedResponseDto(feed);
+                feedMapper.feedToFeedResponseDto(feed, isLike);
 
         return new ResponseEntity<>(feedResponseDto, HttpStatus.OK);
     }
 
     //선택한 카테고리 내의 피드 전체 조회
     @GetMapping("/get/{categoryId}")
-    public ResponseEntity getFeedsByCategory(@PathVariable @Min(0) @Max(13) long categoryId, @RequestParam int page, @RequestParam int size) {
+    public ResponseEntity getFeedsByCategory(@PathVariable @Min(0) @Max(13) long categoryId, @RequestParam int page, @RequestParam int size,
+                                             @AuthenticationPrincipal PrincipalDto principal) {
         Page<Feed> pageFeeds = feedServiceImpl.findAllFeedByCategory(categoryId, page-1, size);
         List<Feed> feeds = pageFeeds.getContent();
+        List<Long> feedIds = feedServiceImpl.isLikeFeedIds(principal.getId());
 
         return new ResponseEntity<>(
                 new MultiResponseDto<>(
-                        feedMapper.feedsToFeedResponseDtos(feeds), pageFeeds), HttpStatus.OK);
+                        feedMapper.feedsToFeedResponseDtos(feeds, feedIds), pageFeeds), HttpStatus.OK);
     }
 
     //카테고리 구분없이 피드 전체 조회
     @GetMapping
-    public ResponseEntity getFeeds(@RequestParam int page, @RequestParam int size) {
+    public ResponseEntity getFeeds(@RequestParam int page, @RequestParam int size,
+                                   @AuthenticationPrincipal PrincipalDto principal) {
         Page<Feed> pageFeeds = feedServiceImpl.findAllFeedByDeleted(page-1, size);
         List<Feed> feeds = pageFeeds.getContent();
+        List<Long> feedIds = feedServiceImpl.isLikeFeedIds(principal.getId());
 
         return new ResponseEntity<>(
                 new MultiResponseDto<>(
-                        feedMapper.feedsToFeedResponseDtos(feeds), pageFeeds), HttpStatus.OK);
+                        feedMapper.feedsToFeedResponseDtos(feeds, feedIds), pageFeeds), HttpStatus.OK);
     }
 
     //일주일 내에 작성된 피드목록 중에 삭제되지 않은 피드들을 좋아요 순으로 조회
     @GetMapping("/weeklybest/{categoryId}")
-    public ResponseEntity getWeeklyBestFeeds(@PathVariable @Min(1) @Max(13) long categoryId, @RequestParam int page, @RequestParam int size) {
+    public ResponseEntity getWeeklyBestFeeds(@PathVariable @Min(1) @Max(13) long categoryId, @RequestParam int page, @RequestParam int size,
+                                             @AuthenticationPrincipal PrincipalDto principal) {
         Page<Feed> pageFeeds = feedServiceImpl.findWeeklyBestFeeds(categoryId, page-1, size);
         List<Feed> feeds = pageFeeds.getContent();
+        List<Long> feedIds = feedServiceImpl.isLikeFeedIds(principal.getId());
 
         return new ResponseEntity<>(
                 new MultiResponseDto<>(
-                        feedMapper.feedsToFeedResponseDtos(feeds), pageFeeds), HttpStatus.OK);
+                        feedMapper.feedsToFeedResponseDtos(feeds, feedIds), pageFeeds), HttpStatus.OK);
     }
 
     //피드 본문 검색
     @GetMapping("/find")
     public ResponseEntity getFeedsBybody(@RequestParam int page,
                                          @RequestParam int size,
-                                         @RequestParam String query) {
+                                         @RequestParam String query,
+                                         @AuthenticationPrincipal PrincipalDto principal) {
         Page<Feed> pageFeeds = feedServiceImpl.findFeedByBody(query, page-1, size);
         List<Feed> feeds = pageFeeds.getContent();
+        List<Long> feedIds = feedServiceImpl.isLikeFeedIds(principal.getId());
 
         return new ResponseEntity<>(
                 new MultiResponseDto<>(
-                        feedMapper.feedsToFeedResponseDtos(feeds), pageFeeds), HttpStatus.OK);
+                        feedMapper.feedsToFeedResponseDtos(feeds, feedIds), pageFeeds), HttpStatus.OK);
     }
 
     //카테고리 내 피드 본문 검색
     @GetMapping("/find/body/{categoryId}")
     public ResponseEntity getFeedsByBodyAndCategory(@PathVariable("categoryId") @Min(0) @Max(13) long categoryId,
                                                     @RequestParam int page,
-                                         @RequestParam int size,
-                                         @RequestParam String query) {
+                                                    @RequestParam int size,
+                                                    @RequestParam String query,
+                                                    @AuthenticationPrincipal PrincipalDto principal) {
         Page<Feed> pageFeeds = feedServiceImpl.findFeedByBodyAndCategory(categoryId, query, page-1, size);
         List<Feed> feeds = pageFeeds.getContent();
+        List<Long> feedIds = feedServiceImpl.isLikeFeedIds(principal.getId());
 
         return new ResponseEntity<>(
                 new MultiResponseDto<>(
-                        feedMapper.feedsToFeedResponseDtos(feeds), pageFeeds), HttpStatus.OK);
+                        feedMapper.feedsToFeedResponseDtos(feeds, feedIds), pageFeeds), HttpStatus.OK);
     }
 
     //카테고리 내 유저 닉네임으로 피드 검색
@@ -126,38 +137,45 @@ public class FeedController {
     public ResponseEntity getFeedsByUserAndCategory(@PathVariable("categoryId") @Min(1) @Max(13) long categoryId,
                                                     @RequestParam int page,
                                                     @RequestParam int size,
-                                                    @RequestParam String query) {
+                                                    @RequestParam String query,
+                                                    @AuthenticationPrincipal PrincipalDto principal) {
         Page<Feed> pageFeeds = feedServiceImpl.findFeedByUserAndCategory(categoryId, query, page-1, size);
         List<Feed> feeds = pageFeeds.getContent();
+        List<Long> feedIds = feedServiceImpl.isLikeFeedIds(principal.getId());
 
         return new ResponseEntity<>(
                 new MultiResponseDto<>(
-                        feedMapper.feedsToFeedResponseDtos(feeds), pageFeeds), HttpStatus.OK);
+                        feedMapper.feedsToFeedResponseDtos(feeds, feedIds), pageFeeds), HttpStatus.OK);
     }
     //HashTagID로 검색
     @GetMapping("/find/hashTagId/{categoryId}")
     public ResponseEntity getFeedsByHashTagAndCategory(@PathVariable("categoryId") @Min(0) @Max(13) long categoryId,
                                                     @RequestParam int page,
                                                     @RequestParam int size,
-                                                    @RequestParam long hashTagId) {
+                                                    @RequestParam long hashTagId,
+                                                    @AuthenticationPrincipal PrincipalDto principal) {
         Page<Feed> pageFeeds = feedServiceImpl.findFeedByHashTagAndCategory(categoryId, hashTagId, page-1, size);
         List<Feed> feeds = pageFeeds.getContent();
+        List<Long> feedIds = feedServiceImpl.isLikeFeedIds(principal.getId());
 
         return new ResponseEntity<>(
                 new MultiResponseDto<>(
-                        feedMapper.feedsToFeedResponseDtos(feeds), pageFeeds), HttpStatus.OK);
+                        feedMapper.feedsToFeedResponseDtos(feeds, feedIds), pageFeeds), HttpStatus.OK);
     }
 
     @GetMapping("/find/hashTag/{categoryId}")
     public ResponseEntity getFeedsByHashTagBody(@PathVariable("categoryId") @Min(0) @Max(13) long categoryId,
                                                 @RequestParam int page,
                                                 @RequestParam int size,
-                                                @RequestParam String body) {
+                                                @RequestParam String body,
+                                                @AuthenticationPrincipal PrincipalDto principal) {
         Page<Feed> pageFeeds = feedServiceImpl.findFeedByHashTagBody(categoryId, body, page - 1, size);
         List<Feed> feeds = pageFeeds.getContent();
+        List<Long> feedIds = feedServiceImpl.isLikeFeedIds(principal.getId());
+
         return new ResponseEntity<>(
                 new MultiResponseDto<>(
-                        feedMapper.feedsToFeedResponseDtos(feeds), pageFeeds), HttpStatus.OK);
+                        feedMapper.feedsToFeedResponseDtos(feeds, feedIds), pageFeeds), HttpStatus.OK);
     }
 
     //피드 본문 수정
@@ -178,10 +196,11 @@ public class FeedController {
                                  @RequestParam int size) {
         Page<Feed> pageFeeds = feedServiceImpl.myPost(principal.getId(), page - 1, size);
         List<Feed> feeds = pageFeeds.getContent();
+        List<Long> feedIds = feedServiceImpl.isLikeFeedIds(principal.getId());
 
         return new ResponseEntity<>(
                 new MultiResponseDto<>(
-                        feedMapper.feedsToFeedResponseDtos(feeds), pageFeeds), HttpStatus.OK);
+                        feedMapper.feedsToFeedResponseDtos(feeds, feedIds), pageFeeds), HttpStatus.OK);
     }
 
     //피드 삭제(DB삭제아님)

--- a/Server/src/main/java/com/codestatus/domain/feed/controller/FeedController.java
+++ b/Server/src/main/java/com/codestatus/domain/feed/controller/FeedController.java
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import java.util.List;
+import java.util.Set;
 
 @Validated
 @RestController
@@ -68,7 +69,7 @@ public class FeedController {
                                              @AuthenticationPrincipal PrincipalDto principal) {
         Page<Feed> pageFeeds = feedServiceImpl.findAllFeedByCategory(categoryId, page-1, size);
         List<Feed> feeds = pageFeeds.getContent();
-        List<Long> feedIds = feedServiceImpl.isLikeFeedIds(principal.getId());
+        Set<Long> feedIds = feedServiceImpl.isLikeFeedIds(feeds, principal);
 
         return new ResponseEntity<>(
                 new MultiResponseDto<>(
@@ -81,7 +82,7 @@ public class FeedController {
                                    @AuthenticationPrincipal PrincipalDto principal) {
         Page<Feed> pageFeeds = feedServiceImpl.findAllFeedByDeleted(page-1, size);
         List<Feed> feeds = pageFeeds.getContent();
-        List<Long> feedIds = feedServiceImpl.isLikeFeedIds(principal.getId());
+        Set<Long> feedIds = feedServiceImpl.isLikeFeedIds(feeds, principal);
 
         return new ResponseEntity<>(
                 new MultiResponseDto<>(
@@ -94,7 +95,7 @@ public class FeedController {
                                              @AuthenticationPrincipal PrincipalDto principal) {
         Page<Feed> pageFeeds = feedServiceImpl.findWeeklyBestFeeds(categoryId, page-1, size);
         List<Feed> feeds = pageFeeds.getContent();
-        List<Long> feedIds = feedServiceImpl.isLikeFeedIds(principal.getId());
+        Set<Long> feedIds = feedServiceImpl.isLikeFeedIds(feeds, principal);
 
         return new ResponseEntity<>(
                 new MultiResponseDto<>(
@@ -109,7 +110,7 @@ public class FeedController {
                                          @AuthenticationPrincipal PrincipalDto principal) {
         Page<Feed> pageFeeds = feedServiceImpl.findFeedByBody(query, page-1, size);
         List<Feed> feeds = pageFeeds.getContent();
-        List<Long> feedIds = feedServiceImpl.isLikeFeedIds(principal.getId());
+        Set<Long> feedIds = feedServiceImpl.isLikeFeedIds(feeds, principal);
 
         return new ResponseEntity<>(
                 new MultiResponseDto<>(
@@ -125,7 +126,7 @@ public class FeedController {
                                                     @AuthenticationPrincipal PrincipalDto principal) {
         Page<Feed> pageFeeds = feedServiceImpl.findFeedByBodyAndCategory(categoryId, query, page-1, size);
         List<Feed> feeds = pageFeeds.getContent();
-        List<Long> feedIds = feedServiceImpl.isLikeFeedIds(principal.getId());
+        Set<Long> feedIds = feedServiceImpl.isLikeFeedIds(feeds, principal);
 
         return new ResponseEntity<>(
                 new MultiResponseDto<>(
@@ -141,7 +142,7 @@ public class FeedController {
                                                     @AuthenticationPrincipal PrincipalDto principal) {
         Page<Feed> pageFeeds = feedServiceImpl.findFeedByUserAndCategory(categoryId, query, page-1, size);
         List<Feed> feeds = pageFeeds.getContent();
-        List<Long> feedIds = feedServiceImpl.isLikeFeedIds(principal.getId());
+        Set<Long> feedIds = feedServiceImpl.isLikeFeedIds(feeds, principal);
 
         return new ResponseEntity<>(
                 new MultiResponseDto<>(
@@ -156,7 +157,7 @@ public class FeedController {
                                                     @AuthenticationPrincipal PrincipalDto principal) {
         Page<Feed> pageFeeds = feedServiceImpl.findFeedByHashTagAndCategory(categoryId, hashTagId, page-1, size);
         List<Feed> feeds = pageFeeds.getContent();
-        List<Long> feedIds = feedServiceImpl.isLikeFeedIds(principal.getId());
+        Set<Long> feedIds = feedServiceImpl.isLikeFeedIds(feeds, principal);
 
         return new ResponseEntity<>(
                 new MultiResponseDto<>(
@@ -171,7 +172,7 @@ public class FeedController {
                                                 @AuthenticationPrincipal PrincipalDto principal) {
         Page<Feed> pageFeeds = feedServiceImpl.findFeedByHashTagBody(categoryId, body, page - 1, size);
         List<Feed> feeds = pageFeeds.getContent();
-        List<Long> feedIds = feedServiceImpl.isLikeFeedIds(principal.getId());
+        Set<Long> feedIds = feedServiceImpl.isLikeFeedIds(feeds, principal);
 
         return new ResponseEntity<>(
                 new MultiResponseDto<>(
@@ -196,7 +197,7 @@ public class FeedController {
                                  @RequestParam int size) {
         Page<Feed> pageFeeds = feedServiceImpl.myPost(principal.getId(), page - 1, size);
         List<Feed> feeds = pageFeeds.getContent();
-        List<Long> feedIds = feedServiceImpl.isLikeFeedIds(principal.getId());
+        Set<Long> feedIds = feedServiceImpl.isLikeFeedIds(feeds, principal);
 
         return new ResponseEntity<>(
                 new MultiResponseDto<>(

--- a/Server/src/main/java/com/codestatus/domain/feed/dto/FeedResponseDto.java
+++ b/Server/src/main/java/com/codestatus/domain/feed/dto/FeedResponseDto.java
@@ -30,6 +30,8 @@ public class FeedResponseDto {
 
     private List<HashTagResponseDto> feedHashTags;
 
+    private boolean isLike;
+
     private int likeCount;
 
 //    private String feedImages;

--- a/Server/src/main/java/com/codestatus/domain/feed/dto/FeedsResponseDto.java
+++ b/Server/src/main/java/com/codestatus/domain/feed/dto/FeedsResponseDto.java
@@ -26,6 +26,8 @@ public class FeedsResponseDto {
 
     private List<HashTagResponseDto> feedHashTags;
 
+    private boolean isLike;
+
     private int likeCount;
 
     private int commentCount;

--- a/Server/src/main/java/com/codestatus/domain/feed/mapper/FeedMapper.java
+++ b/Server/src/main/java/com/codestatus/domain/feed/mapper/FeedMapper.java
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
 @Mapper(componentModel = "spring")
 public interface FeedMapper {
 
-    default FeedResponseDto feedToFeedResponseDto(Feed feed){
+    default FeedResponseDto feedToFeedResponseDto(Feed feed, boolean isLike){
         return FeedResponseDto.builder()
                 .feedId(feed.getFeedId())
                 .nickname(feed.getUser().getNickname())
@@ -31,6 +31,7 @@ public interface FeedMapper {
                                 .body(feedHashTag.getHashTag().getBody())
                                 .build())
                         .collect(Collectors.toList()))
+                .isLike(isLike)
                 .likeCount((int)feed.getLikes().stream().filter(like -> !like.getDeleted()).count())
                 .comments(feed.getComments().stream()
                         .filter(comment -> !comment.isDeleted())
@@ -48,7 +49,7 @@ public interface FeedMapper {
                 .build();
     }
 
-    default List<FeedsResponseDto> feedsToFeedResponseDtos(List<Feed> feeds){
+    default List<FeedsResponseDto> feedsToFeedResponseDtos(List<Feed> feeds, List<Long> feedIds){
         return feeds.stream()
                 .map(feed -> FeedsResponseDto
                         .builder()
@@ -64,6 +65,7 @@ public interface FeedMapper {
                                         .body(feedHashTag.getHashTag().getBody())
                                         .build())
                                 .collect(Collectors.toList()))
+                        .isLike(feedIds.contains(feed.getFeedId()))
                         .likeCount((int)feed.getLikes().stream().filter(like -> !like.getDeleted()).count())
                         .commentCount((int) feed.getComments().stream()
                                 .filter(comment -> !comment.isDeleted())
@@ -72,7 +74,6 @@ public interface FeedMapper {
                         .modifiedAt(feed.getModifiedAt())
                         .build())
                 .collect(Collectors.toList());
-
     }
     default Feed feedPostDtoToFeed(Category category, FeedPostDto requestBody, User user){
         Feed feed = new Feed();

--- a/Server/src/main/java/com/codestatus/domain/feed/mapper/FeedMapper.java
+++ b/Server/src/main/java/com/codestatus/domain/feed/mapper/FeedMapper.java
@@ -12,6 +12,7 @@ import com.codestatus.domain.user.entity.User;
 import org.mapstruct.Mapper;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Mapper(componentModel = "spring")
@@ -49,7 +50,7 @@ public interface FeedMapper {
                 .build();
     }
 
-    default List<FeedsResponseDto> feedsToFeedResponseDtos(List<Feed> feeds, List<Long> feedIds){
+    default List<FeedsResponseDto> feedsToFeedResponseDtos(List<Feed> feeds, Set<Long> feedIds){
         return feeds.stream()
                 .map(feed -> FeedsResponseDto
                         .builder()

--- a/Server/src/main/java/com/codestatus/domain/feed/repository/FeedRepository.java
+++ b/Server/src/main/java/com/codestatus/domain/feed/repository/FeedRepository.java
@@ -16,6 +16,8 @@ public interface FeedRepository extends JpaRepository <Feed, Long> {
     @Query("SELECT f FROM Feed f WHERE f.feedId = :feedId AND f.deleted = false ")
     Optional<Feed> findFeedByFeedIdAndDeletedIsFalse(long feedId);
 
+    List<Feed> findByLikesUserUserIdAndLikesDeletedIsFalse(long userId);
+
     @Query(nativeQuery = true, value = "SELECT f FROM Feed f WHERE f.body LIKE %:body% AND f.deleted = false ")
     Page<Feed> findByBodyAndDeletedIsFalse(@Param("body") String body, Pageable pageable);
 

--- a/Server/src/main/java/com/codestatus/domain/feed/repository/FeedRepository.java
+++ b/Server/src/main/java/com/codestatus/domain/feed/repository/FeedRepository.java
@@ -9,20 +9,11 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 public interface FeedRepository extends JpaRepository <Feed, Long> {
-
-    @Query("SELECT f FROM Feed f WHERE f.feedId = :feedId AND f.deleted = false ")
-    Optional<Feed> findFeedByFeedIdAndDeletedIsFalse(long feedId);
-
-//    @Query("SELECT f FROM Feed f WHERE f IN :feeds AND f IN (SELECT l.feed FROM likes l WHERE l.user.userId = :userId AND l.deleted = false)")
-//    Set<Feed> findByInFeedsLikesAndLikesUserUserIdAndLikesDeletedIsFalse(List<Feed> feeds, long userId);
-
-    @Query("SELECT f FROM Feed f JOIN f.likes l WHERE l.user.userId = :userId AND l.deleted = false AND f IN :feeds")
-    Set<Feed> findFeedsLikedByUserInList(long userId, List<Feed> feeds);
-
+    @Query("SELECT f FROM Feed f JOIN f.likes l WHERE f IN :feeds AND l.user.userId = :userId AND l.deleted = false")
+    Set<Feed> findFeedsLikedByUserInList(@Param("userId") long userId, @Param("feeds") List<Feed> feeds);
 
     @Query(nativeQuery = true, value = "SELECT f FROM Feed f WHERE f.body LIKE %:body% AND f.deleted = false ")
     Page<Feed> findByBodyAndDeletedIsFalse(@Param("body") String body, Pageable pageable);

--- a/Server/src/main/java/com/codestatus/domain/feed/repository/FeedRepository.java
+++ b/Server/src/main/java/com/codestatus/domain/feed/repository/FeedRepository.java
@@ -17,8 +17,12 @@ public interface FeedRepository extends JpaRepository <Feed, Long> {
     @Query("SELECT f FROM Feed f WHERE f.feedId = :feedId AND f.deleted = false ")
     Optional<Feed> findFeedByFeedIdAndDeletedIsFalse(long feedId);
 
-    @Query("SELECT DISTINCT f FROM Feed f WHERE f IN :feeds AND f IN (SELECT l.feed FROM likes l WHERE l.user.userId = :userId AND l.deleted = false)")
-    Set<Feed> findByInFeedsLikesAndLikesUserUserIdAndLikesDeletedIsFalse(List<Feed> feeds, long userId);
+//    @Query("SELECT f FROM Feed f WHERE f IN :feeds AND f IN (SELECT l.feed FROM likes l WHERE l.user.userId = :userId AND l.deleted = false)")
+//    Set<Feed> findByInFeedsLikesAndLikesUserUserIdAndLikesDeletedIsFalse(List<Feed> feeds, long userId);
+
+    @Query("SELECT f FROM Feed f JOIN f.likes l WHERE l.user.userId = :userId AND l.deleted = false AND f IN :feeds")
+    Set<Feed> findFeedsLikedByUserInList(long userId, List<Feed> feeds);
+
 
     @Query(nativeQuery = true, value = "SELECT f FROM Feed f WHERE f.body LIKE %:body% AND f.deleted = false ")
     Page<Feed> findByBodyAndDeletedIsFalse(@Param("body") String body, Pageable pageable);

--- a/Server/src/main/java/com/codestatus/domain/feed/repository/FeedRepository.java
+++ b/Server/src/main/java/com/codestatus/domain/feed/repository/FeedRepository.java
@@ -10,13 +10,15 @@ import org.springframework.data.repository.query.Param;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface FeedRepository extends JpaRepository <Feed, Long> {
 
     @Query("SELECT f FROM Feed f WHERE f.feedId = :feedId AND f.deleted = false ")
     Optional<Feed> findFeedByFeedIdAndDeletedIsFalse(long feedId);
 
-    List<Feed> findByLikesUserUserIdAndLikesDeletedIsFalse(long userId);
+    @Query("SELECT DISTINCT f FROM Feed f WHERE f IN :feeds AND f IN (SELECT l.feed FROM likes l WHERE l.user.userId = :userId AND l.deleted = false)")
+    Set<Feed> findByInFeedsLikesAndLikesUserUserIdAndLikesDeletedIsFalse(List<Feed> feeds, long userId);
 
     @Query(nativeQuery = true, value = "SELECT f FROM Feed f WHERE f.body LIKE %:body% AND f.deleted = false ")
     Page<Feed> findByBodyAndDeletedIsFalse(@Param("body") String body, Pageable pageable);

--- a/Server/src/main/java/com/codestatus/domain/feed/service/FeedServiceImpl.java
+++ b/Server/src/main/java/com/codestatus/domain/feed/service/FeedServiceImpl.java
@@ -49,6 +49,7 @@ public class FeedServiceImpl implements FeedService {
         return likeCommand.checkIsLikeUser(feedId, userId);
     }
 
+    //피드리스트에서 유저가 좋아요한 피드 아이디셋
     public Set<Long> isLikeFeedIds(List<Feed> feeds, PrincipalDto principal) {
         if(principal == null){
             return Collections.emptySet();

--- a/Server/src/main/java/com/codestatus/domain/feed/service/FeedServiceImpl.java
+++ b/Server/src/main/java/com/codestatus/domain/feed/service/FeedServiceImpl.java
@@ -5,6 +5,7 @@ import com.codestatus.domain.feed.command.FeedCommand;
 import com.codestatus.domain.hashTag.command.FeedHashTagCommand;
 import com.codestatus.domain.feed.entity.Feed;
 import com.codestatus.domain.feed.repository.FeedRepository;
+import com.codestatus.domain.like.likeCommand.LikeCommand;
 import com.codestatus.global.utils.CheckUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -17,7 +18,9 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Transactional
 @Service
@@ -28,6 +31,7 @@ public class FeedServiceImpl implements FeedService {
     private final FeedCommand feedCommand;
     private final FeedHashTagCommand feedHashTagCommand;
     private final CommentCommand commentCommand;
+    private final LikeCommand likeCommand;
 
     @Override
     public void createEntity(Feed feed) {
@@ -36,6 +40,16 @@ public class FeedServiceImpl implements FeedService {
 
     public Feed findEntity(long feedId) {
         return feedCommand.findVerifiedFeed(feedId);
+    }
+
+    public boolean isLikeUser(long feedId, long userId) {
+        return likeCommand.checkIsLikeUser(feedId, userId);
+    }
+
+    public List<Long> isLikeFeedIds(long userId) {
+        List<Feed> feeds = feedRepository.findByLikesUserUserIdAndLikesDeletedIsFalse(userId);
+        List<Long> feedIds = feeds.stream().map(Feed::getFeedId).collect(Collectors.toList());
+        return feedIds;
     }
 
     //카테고리 내 피드리스트 조회

--- a/Server/src/main/java/com/codestatus/domain/feed/service/FeedServiceImpl.java
+++ b/Server/src/main/java/com/codestatus/domain/feed/service/FeedServiceImpl.java
@@ -6,6 +6,7 @@ import com.codestatus.domain.hashTag.command.FeedHashTagCommand;
 import com.codestatus.domain.feed.entity.Feed;
 import com.codestatus.domain.feed.repository.FeedRepository;
 import com.codestatus.domain.like.likeCommand.LikeCommand;
+import com.codestatus.global.auth.dto.PrincipalDto;
 import com.codestatus.global.utils.CheckUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -18,8 +19,10 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Transactional
@@ -46,10 +49,16 @@ public class FeedServiceImpl implements FeedService {
         return likeCommand.checkIsLikeUser(feedId, userId);
     }
 
-    public List<Long> isLikeFeedIds(long userId) {
-        List<Feed> feeds = feedRepository.findByLikesUserUserIdAndLikesDeletedIsFalse(userId);
-        List<Long> feedIds = feeds.stream().map(Feed::getFeedId).collect(Collectors.toList());
-        return feedIds;
+    public Set<Long> isLikeFeedIds(List<Feed> feeds, PrincipalDto principal) {
+        if(principal == null){
+            return Collections.emptySet();
+        }
+        Set<Long> likedFeedIds = feedRepository
+                .findByInFeedsLikesAndLikesUserUserIdAndLikesDeletedIsFalse(feeds, principal.getId())
+                .stream()
+                .map(Feed::getFeedId)
+                .collect(Collectors.toSet());
+        return likedFeedIds;
     }
 
     //카테고리 내 피드리스트 조회

--- a/Server/src/main/java/com/codestatus/domain/feed/service/FeedServiceImpl.java
+++ b/Server/src/main/java/com/codestatus/domain/feed/service/FeedServiceImpl.java
@@ -54,7 +54,7 @@ public class FeedServiceImpl implements FeedService {
             return Collections.emptySet();
         }
         Set<Long> likedFeedIds = feedRepository
-                .findByInFeedsLikesAndLikesUserUserIdAndLikesDeletedIsFalse(feeds, principal.getId())
+                .findFeedsLikedByUserInList(principal.getId(), feeds)
                 .stream()
                 .map(Feed::getFeedId)
                 .collect(Collectors.toSet());

--- a/Server/src/main/java/com/codestatus/domain/like/likeCommand/LikeCommand.java
+++ b/Server/src/main/java/com/codestatus/domain/like/likeCommand/LikeCommand.java
@@ -1,0 +1,23 @@
+package com.codestatus.domain.like.likeCommand;
+
+import com.codestatus.domain.like.entity.Like;
+import com.codestatus.domain.like.repository.LikeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Transactional
+@Component
+public class LikeCommand {
+
+    private final LikeRepository likeRepository;
+
+    public boolean checkIsLikeUser(long feedId, long userId){
+        Optional<Like> optionalLike = likeRepository.findLikeByFeedFeedIdAndUserUserIdAndDeletedIsFalse(feedId, userId);
+        return optionalLike.isPresent();
+    }
+
+}

--- a/Server/src/main/java/com/codestatus/domain/like/repository/LikeRepository.java
+++ b/Server/src/main/java/com/codestatus/domain/like/repository/LikeRepository.java
@@ -4,11 +4,13 @@ import com.codestatus.domain.feed.entity.Feed;
 import com.codestatus.domain.like.entity.Like;
 import com.codestatus.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
 //    @Query(nativeQuery = true, value = "SELECT * FROM like WHERE feed_id=:feed AND user_id=:user")
     Optional<Like> findLikeByFeedAndUser(Feed feed, User user);
+
+    Optional<Like> findLikeByFeedFeedIdAndUserUserIdAndDeletedIsFalse(long feedId, long userId);
 }


### PR DESCRIPTION
✨ feat: 피드 상세 조회, 피드 리스트 조회 하면 해당 유저가 피드 좋아요 했는지 표시

- ResponseDto, ResponseDtos에 isLike 추가.
- 모든 피드 조회할때 추가
- MyPost는 본인 글에 좋아요 표시를 못하기 때문에 필요없지만 같은 Dto를 사용해서 넣어주었습니다.

추가) 연성님 피드백 반영했습니다!
♻️ refactor: 피드 좋아요 확인하는 기능 리팩토링. 기존 userId로만 했는데 feeds도 활용하게 해서 DB부하 줄임
✨ feat: 로그인 안했다면 좋아요 누른 피드조회하지 않음.

추가2) 연성님의 피드백 듣고 더 효율적인 쿼리 짜보았습니다.
♻️ refactor: 기존에 likes전체를 조회해서 가져왔는데 이제 feeds에서 범위를 좁히고 likes를 조회합니다.

추가3) 연성님 피드백을 듣고 IN :Feeds위치를 앞으로 당겼습니다.

