### PR TITLE
🐛 fix: add jwtException when refresh token doesn't exist

### DIFF
--- a/Server/src/main/java/com/codestatus/global/auth/filter/JwtVerificationFilter.java
+++ b/Server/src/main/java/com/codestatus/global/auth/filter/JwtVerificationFilter.java
@@ -6,6 +6,8 @@ import com.codestatus.global.auth.userdetails.UsersDetailService;
 import com.codestatus.global.auth.utils.CustomAuthorityUtils;
 import com.codestatus.global.auth.utils.JwtResponseUtil;
 import com.codestatus.domain.user.entity.User;
+import com.codestatus.global.exception.BusinessLogicException;
+import com.codestatus.global.exception.ExceptionCode;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.security.SignatureException;
@@ -24,6 +26,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 public class JwtVerificationFilter extends OncePerRequestFilter {
@@ -49,6 +52,8 @@ public class JwtVerificationFilter extends OncePerRequestFilter {
                 request.setAttribute("exception", new JwtException("Access token has expired"));
             } catch (ExpiredJwtException refreshEx) {
                 request.setAttribute("exception", new JwtException("Refresh token has expired"));
+            } catch (JwtException jwtException) {
+                request.setAttribute("exception", jwtException);
             }
         } catch (Exception e) {
             request.setAttribute("exception", e);
@@ -69,7 +74,8 @@ public class JwtVerificationFilter extends OncePerRequestFilter {
 
     private String verifyRefreshJWS(HttpServletRequest request) {
         String jws = "";
-        for(Cookie cookie:request.getCookies()) {
+        Cookie[] cookies = Optional.ofNullable(request.getCookies()).orElseThrow(() -> new JwtException("RefreshToken doesn't exists"));
+        for(Cookie cookie:cookies) {
             if(cookie.getName().equals("Refresh")){
                 jws = cookie.getValue();
                 break;

--- a/Server/src/main/java/com/codestatus/global/auth/handler/UserAuthenticationEntryPoint.java
+++ b/Server/src/main/java/com/codestatus/global/auth/handler/UserAuthenticationEntryPoint.java
@@ -21,10 +21,11 @@ public class UserAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
         Exception exception = (Exception) request.getAttribute("exception");
 
-        //Access 토큰 만료시 메세지 커스텀
-        if (exception instanceof ExpiredJwtException || exception instanceof SignatureException)
-            ErrorResponseSender.sendResponse(response, HttpStatus.UNAUTHORIZED, "JWT Expired");
-        else
-            ErrorResponseSender.sendResponse(response, HttpStatus.UNAUTHORIZED, "권한이 없습니다.");
+        ErrorResponseSender.sendResponse(response, HttpStatus.UNAUTHORIZED, exception.getMessage());
+//        //Access 토큰 만료시 메세지 커스텀
+//        if (exception instanceof ExpiredJwtException || exception instanceof SignatureException)
+//            ErrorResponseSender.sendResponse(response, HttpStatus.UNAUTHORIZED, "JWT Expired");
+//        else
+//            ErrorResponseSender.sendResponse(response, HttpStatus.UNAUTHORIZED, "권한이 없습니다.");
     }
 }


### PR DESCRIPTION
🐛 fix: add jwtException when refresh token doesn't exist
- access token이 만료된 상황에서 refresh token이 존재하지 않을 때 발생했던 500에러를 해결했습니다.
- 해당 상황일 때 status code 401이고 message는 RefreshToken doesn't exists 라고 반환합니다.

Test Case:
- postman을 사용해 만료된 access token만 넣고 feed 작성 api를 호출하여 예상한 에러 메세지가 response로 나왔습니다.