### PR TITLE
🐛 fix: feed 본문 및 comment 글자수 제한 추가

### DIFF
--- a/Server/src/main/java/com/codestatus/domain/comment/dto/CommentPostDto.java
+++ b/Server/src/main/java/com/codestatus/domain/comment/dto/CommentPostDto.java
@@ -5,11 +5,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
 
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
 public class CommentPostDto {
     @NotBlank
+    @Size(max = 255, message = "댓글 글자수 초과")
     private String body;
 }

--- a/Server/src/main/java/com/codestatus/domain/comment/dto/CommnetPatchDto.java
+++ b/Server/src/main/java/com/codestatus/domain/comment/dto/CommnetPatchDto.java
@@ -4,11 +4,14 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
 
 @Getter
 @AllArgsConstructor
 public class CommnetPatchDto {
     private Long id;
+
     @NotBlank
+    @Size(max = 255, message = "댓글 글자수 초과")
     private String body;
 }

--- a/Server/src/main/java/com/codestatus/domain/feed/controller/FeedController.java
+++ b/Server/src/main/java/com/codestatus/domain/feed/controller/FeedController.java
@@ -20,6 +20,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import java.util.List;
@@ -40,7 +41,7 @@ public class FeedController {
     //선택한 카테고리에 피드 작성
     @PostMapping("/{categoryId}")
     public ResponseEntity postFeed(@PathVariable("categoryId") @Min(1) @Max(13) long categoryId,
-                                   @RequestBody FeedPostDto requestBody,
+                                   @Valid @RequestBody FeedPostDto requestBody,
                                    @AuthenticationPrincipal PrincipalDto principal) {
         Feed feed = feedMapper.feedPostDtoToFeed(
                 categoryMapper.categoryIdToCategory(categoryId),
@@ -171,7 +172,7 @@ public class FeedController {
     //피드 본문 수정
     @PatchMapping("/{feedId}")
     public ResponseEntity patchFeed(@PathVariable("feedId") int feedId,
-                                    @RequestBody FeedPatchDto requestBody,
+                                    @Valid @RequestBody FeedPatchDto requestBody,
                                     @AuthenticationPrincipal PrincipalDto principal){
         Feed feed = feedMapper.feedPatchDtoToFeed(requestBody);
         feed.setFeedId(feedId);

--- a/Server/src/main/java/com/codestatus/domain/feed/dto/FeedPatchDto.java
+++ b/Server/src/main/java/com/codestatus/domain/feed/dto/FeedPatchDto.java
@@ -4,6 +4,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
+import javax.validation.constraints.Size;
+
 @Getter
 @Setter
 @AllArgsConstructor
@@ -11,6 +13,7 @@ public class FeedPatchDto {
 
     private long id;
 
+    @Size(max = 1024, message = "본문 글자수 초과")
     private String body;
     private String data;
 }

--- a/Server/src/main/java/com/codestatus/domain/feed/dto/FeedPostDto.java
+++ b/Server/src/main/java/com/codestatus/domain/feed/dto/FeedPostDto.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
 import java.util.List;
 
 @Getter
@@ -13,6 +15,7 @@ import java.util.List;
 public class FeedPostDto {
 
     @NotBlank
+    @Size(max = 1024, message = "본문 글자수 초과")
     private String body;
 
     private String data;


### PR DESCRIPTION
- feed 본문 및 comment 글자수 제한 추가 했습니다.
- feed 의 body 1024 자 제한
- comment 의 body 255 자 제한
- 작성 및 예외처리 테스트 완료 했습니다.