### PR TITLE
🐛 fix: access token 재발급 수정, ✨ feat: jwt 인증 오류 error response 세분화

### DIFF
--- a/Server/src/main/java/com/codestatus/global/auth/handler/UserAuthenticationEntryPoint.java
+++ b/Server/src/main/java/com/codestatus/global/auth/handler/UserAuthenticationEntryPoint.java
@@ -1,10 +1,12 @@
 package com.codestatus.global.auth.handler;
 
 import com.codestatus.global.auth.utils.ErrorResponseSender;
-import io.jsonwebtoken.ExpiredJwtException;
+import com.codestatus.global.exception.AccessTokenExpiredException;
+import com.codestatus.global.exception.RefreshTokenExpiredException;
 import io.jsonwebtoken.security.SignatureException;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.jwt.BadJwtException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
@@ -20,12 +22,15 @@ public class UserAuthenticationEntryPoint implements AuthenticationEntryPoint {
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
 
         Exception exception = (Exception) request.getAttribute("exception");
-
-        ErrorResponseSender.sendResponse(response, HttpStatus.UNAUTHORIZED, exception.getMessage());
 //        //Access 토큰 만료시 메세지 커스텀
-//        if (exception instanceof ExpiredJwtException || exception instanceof SignatureException)
-//            ErrorResponseSender.sendResponse(response, HttpStatus.UNAUTHORIZED, "JWT Expired");
-//        else
-//            ErrorResponseSender.sendResponse(response, HttpStatus.UNAUTHORIZED, "권한이 없습니다.");
+        if (exception instanceof AccessTokenExpiredException) {
+            String token = String.valueOf(request.getAttribute("token"));
+            ErrorResponseSender.sendResponse(response, HttpStatus.UNAUTHORIZED, exception.getMessage(), token);
+        }
+        else if (exception instanceof RefreshTokenExpiredException || exception instanceof SignatureException || exception instanceof BadJwtException){
+            ErrorResponseSender.sendResponse(response, HttpStatus.UNAUTHORIZED, exception.getMessage());
+        }
+
+        else ErrorResponseSender.sendResponse(response, HttpStatus.UNAUTHORIZED, authException.getMessage());
     }
 }

--- a/Server/src/main/java/com/codestatus/global/auth/utils/ErrorResponseSender.java
+++ b/Server/src/main/java/com/codestatus/global/auth/utils/ErrorResponseSender.java
@@ -2,6 +2,7 @@ package com.codestatus.global.auth.utils;
 
 import com.codestatus.global.exception.ExceptionCode;
 import com.codestatus.global.response.ErrorResponse;
+import com.codestatus.global.response.JwtErrorResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -20,7 +21,11 @@ public class ErrorResponseSender {
         sendResponse(response,status, errorResponse);
     }
 
-    private static void sendResponse(HttpServletResponse response, HttpStatus status, ErrorResponse errorResponse) throws IOException {
+    public static void sendResponse(HttpServletResponse response, HttpStatus status, String message, String token) throws IOException {
+        JwtErrorResponse errorResponse = JwtErrorResponse.of(status, message, token);
+        sendResponse(response, status, errorResponse);
+    }
+    private static void sendResponse(HttpServletResponse response, HttpStatus status, Object errorResponse) throws IOException {
         ObjectMapper mapper = new ObjectMapper();
         String errorJson = mapper.writeValueAsString(errorResponse);
 

--- a/Server/src/main/java/com/codestatus/global/auth/utils/JwtResponseUtil.java
+++ b/Server/src/main/java/com/codestatus/global/auth/utils/JwtResponseUtil.java
@@ -17,9 +17,7 @@ public class JwtResponseUtil {
     private final JwtTokenizer jwtTokenizer;
 
     public void setAccessToken(User user, HttpServletResponse response) throws IOException {
-        String accessToken = jwtTokenizer.generateAccessToken(user);
-
-        String responseTokenString = "Bearer " + accessToken;
+        String responseTokenString = getResponseTokenString(user);
         ObjectMapper objectMapper = new ObjectMapper();
         String jsonResponse = objectMapper.writeValueAsString(Collections.singletonMap("token", responseTokenString));
 
@@ -30,5 +28,9 @@ public class JwtResponseUtil {
         String refreshToken = jwtTokenizer.generateRefreshToken(user);
         Cookie cookie = new Cookie("Refresh", refreshToken);
         response.addCookie(cookie);
+    }
+
+    public String getResponseTokenString(User user) {
+        return "Bearer " + jwtTokenizer.generateAccessToken(user);
     }
 }

--- a/Server/src/main/java/com/codestatus/global/exception/AccessTokenExpiredException.java
+++ b/Server/src/main/java/com/codestatus/global/exception/AccessTokenExpiredException.java
@@ -1,0 +1,11 @@
+package com.codestatus.global.exception;
+
+import io.jsonwebtoken.JwtException;
+import lombok.Getter;
+
+@Getter
+public class AccessTokenExpiredException extends JwtException {
+    public AccessTokenExpiredException() {
+        super("Access token has expired");
+    }
+}

--- a/Server/src/main/java/com/codestatus/global/exception/RefreshTokenExpiredException.java
+++ b/Server/src/main/java/com/codestatus/global/exception/RefreshTokenExpiredException.java
@@ -1,0 +1,9 @@
+package com.codestatus.global.exception;
+
+import io.jsonwebtoken.JwtException;
+
+public class RefreshTokenExpiredException extends JwtException {
+    public RefreshTokenExpiredException() {
+        super("Refresh token has expired");
+    }
+}

--- a/Server/src/main/java/com/codestatus/global/response/ErrorResponse.java
+++ b/Server/src/main/java/com/codestatus/global/response/ErrorResponse.java
@@ -22,4 +22,5 @@ public class ErrorResponse {
 
     public static ErrorResponse of(HttpStatus httpStatus, String message) {
         return new ErrorResponse(httpStatus.value(), message, String.valueOf(httpStatus.value()));
-    }}
+    }
+}

--- a/Server/src/main/java/com/codestatus/global/response/JwtErrorResponse.java
+++ b/Server/src/main/java/com/codestatus/global/response/JwtErrorResponse.java
@@ -1,0 +1,19 @@
+package com.codestatus.global.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public class JwtErrorResponse {
+    private int status;
+    private String message;
+    private final String errorCode = "T000";
+    private String token;
+
+
+    public static JwtErrorResponse of(HttpStatus httpStatus, String message, String token) {
+        return new JwtErrorResponse(httpStatus.value(), message, token);
+    }
+}


### PR DESCRIPTION
🐛 fix: access token 재발급 수정
- refresh token은 유효한 상태에서 access token을 재발급 받을 때, nullpointerror가 뜨는 것을 수정하였습니다.
- 재발급한 access token을 보내기 위한 error response를 추가하였습니다.

✨ feat: jwt 인증 오류 error response 세분화
- jwt 인증 오류 시 발생하는 오류들에 대해 조금 더 세분화 하였습니다.

Test Case:
postman 사용하여 token 위변조 오류, 기한 만료 오류, access token 재발급이 잘 되는지 확인하였습니다.