### PR TITLE
✨ feat: add kakao oauth2 login

### DIFF
--- a/Server/src/main/java/com/codestatus/global/auth/handler/OAuth2UserSuccessHandler.java
+++ b/Server/src/main/java/com/codestatus/global/auth/handler/OAuth2UserSuccessHandler.java
@@ -30,7 +30,8 @@ public class OAuth2UserSuccessHandler extends SimpleUrlAuthenticationSuccessHand
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
         var oAuth2User = (OAuth2User)authentication.getPrincipal();
-        String email = String.valueOf(oAuth2User.getAttributes().get("email"));
+
+        String email = getEmail(oAuth2User);
         String path = "";
         MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         try {
@@ -42,6 +43,11 @@ public class OAuth2UserSuccessHandler extends SimpleUrlAuthenticationSuccessHand
         }
         String uri = createURI(queryParams, path).toString();
         getRedirectStrategy().sendRedirect(request, response, uri);
+    }
+    private String getEmail(OAuth2User oAuth2User) {
+        if (oAuth2User.getAttributes().containsKey("email")) return (String) oAuth2User.getAttributes().get("email");
+        Map<String, Object> kakaoAccount = (Map<String, Object>) oAuth2User.getAttributes().get("kakao_account");
+        return (String) kakaoAccount.get("email");
     }
 
     private URI createURI(MultiValueMap<String, String> queryParams, String path) {

--- a/Server/src/main/resources/application.yml
+++ b/Server/src/main/resources/application.yml
@@ -37,6 +37,21 @@ spring:
             scope:
               - email
               - profile
+          kakao:
+            clientId: ${KAKAO_CLIENT_ID}
+            clientSecret: ${KAKAO_SECRET}
+            redirectUri: http://localhost:8080/login/oauth2/code/kakao
+            clientAuthenticationMethod: POST
+            authorizationGrantType: authorization_code
+            clientName: Kakao
+            scope:
+              - account_email
+        provider:
+          kakao:
+            authorization_uri: https://kauth.kakao.com/oauth/authorize
+            token_uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user_name_attribute: id
   mail:
     host: smtp.gmail.com
     port: 587


### PR DESCRIPTION
✨ feat: add kakao oauth2 login
- Oauth2SuccessHandler에 카카오 oauth2 로그인 과정을 추가하였습니다.
- .yml에 카카오 oauth2 로그인을 위한 설정을 추가하였습니다.

Test Case:
- 로컬 환경에서 chrome client로 kako 로그인 성공 했습니다.

PS:
- front에서 로그인, 회원가입 페이지 url을 받아 
Oauth2SuceessHandler에서 redirect url을 바꿔야 합니다.