### PR TITLE
🐛 fix: get user status on custom user details

### DIFF
--- a/Server/src/main/java/com/codestatus/global/auth/userdetails/UsersDetailService.java
+++ b/Server/src/main/java/com/codestatus/global/auth/userdetails/UsersDetailService.java
@@ -9,10 +9,12 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collection;
 import java.util.List;
 
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Component
 public class UsersDetailService implements UserDetailsService {
@@ -36,6 +38,7 @@ public class UsersDetailService implements UserDetailsService {
             setEmail(user.getEmail());
             setPassword(user.getPassword());
             setRoles(user.getRoles());
+            setUserStatus(user.getUserStatus());
         }
 
         @Override


### PR DESCRIPTION
🐛 fix: get user status on custom user details
- 로그인 시 active 상태가 아닌 유저들의 로그인이 되던 문제를 해결했습니다.
