### PR TITLE
🐛 fix: 재가입 user 처리

### DIFF
--- a/Server/src/main/java/com/codestatus/domain/status/command/StatusCommand.java
+++ b/Server/src/main/java/com/codestatus/domain/status/command/StatusCommand.java
@@ -1,0 +1,45 @@
+package com.codestatus.domain.status.command;
+
+import com.codestatus.domain.status.entity.Stat;
+import com.codestatus.domain.status.entity.Status;
+import com.codestatus.domain.status.repository.StatusRepository;
+import com.codestatus.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Transactional
+public class StatusCommand {
+    private final StatusRepository statusRepository;
+    public void createStatus(User user) {
+        List<Status> statusList = new ArrayList<>();
+        for(int i = 1; i <= 5 ; i++) {
+            Stat stat = new Stat();
+            stat.setStatId((long) i);
+
+            Status status = new Status();
+            status.setUser(user);
+            status.setStat(stat);
+            status.setStatLevel(1);
+            status.setStatExp(0);
+            status.setRequiredExp(100); // 초기 필요 경험치 설정(level1 -> level2)
+            statusList.add(status);
+        }
+        statusRepository.saveAll(statusList);
+    }
+
+    public void resetStatus(long userId) {
+        List<Status> statusList = statusRepository.findAllByUserUserId(userId);
+        for (Status status : statusList) {
+            status.setStatLevel(1);
+            status.setStatExp(0);
+            status.setRequiredExp(100);
+        }
+        statusRepository.saveAll(statusList);
+    }
+}

--- a/Server/src/main/java/com/codestatus/domain/status/repository/StatusRepository.java
+++ b/Server/src/main/java/com/codestatus/domain/status/repository/StatusRepository.java
@@ -3,6 +3,8 @@ package com.codestatus.domain.status.repository;
 import com.codestatus.domain.status.entity.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface StatusRepository extends JpaRepository<Status, Long> {
+import java.util.List;
 
+public interface StatusRepository extends JpaRepository<Status, Long> {
+    List<Status> findAllByUserUserId(long userId);
 }

--- a/Server/src/main/java/com/codestatus/domain/user/entity/User.java
+++ b/Server/src/main/java/com/codestatus/domain/user/entity/User.java
@@ -51,9 +51,6 @@ public class User extends Auditable {
     @JsonIgnore
     private List<Status> statuses = new ArrayList<>();
 
-    // 피드 매핑해야 함
-    // 코멘트 매핑해야 함
-
     public User(String email) {
         this.email = email;
     }

--- a/Server/src/main/java/com/codestatus/domain/user/service/UserServiceImpl.java
+++ b/Server/src/main/java/com/codestatus/domain/user/service/UserServiceImpl.java
@@ -80,7 +80,7 @@ public class UserServiceImpl implements UserService {
         findUser.setUserStatus(User.UserStatus.USER_ACTIVE); // user status 를 ACTIVE 로 변경
         findUser.setPassword(passwordEncoder.encode(password)); // 비밀번호 암호화
         if (findUser.getNickname().equals(nickname)) { // DB 의 닉네임과 재가입시 입력한 닉네임이 같다면
-            findUser.setNickname(nickname); // 중복검사를 하지 않고 닉네임 set
+            return;
         } else { // DB 의 닉네임과 재가입시 입력한 닉네임이 다르다면
             verifyExistsNickname(nickname); // 다른 유저와의 닉네임 중복검사
             findUser.setNickname(nickname); // 중복검사 통과시 닉네임 set

--- a/Server/src/main/java/com/codestatus/domain/user/service/UserServiceImpl.java
+++ b/Server/src/main/java/com/codestatus/domain/user/service/UserServiceImpl.java
@@ -3,6 +3,7 @@ package com.codestatus.domain.user.service;
 import com.codestatus.domain.comment.command.CommentCommand;
 import com.codestatus.domain.feed.command.FeedCommand;
 import com.codestatus.domain.hashTag.command.FeedHashTagCommand;
+import com.codestatus.domain.status.command.StatusCommand;
 import com.codestatus.domain.user.command.UserCommand;
 import com.codestatus.global.auth.utils.CustomAuthorityUtils;
 import com.codestatus.global.aws.FileStorageService;
@@ -35,8 +36,7 @@ public class UserServiceImpl implements UserService {
     private final FeedCommand feedCommand;
     private final FeedHashTagCommand feedHashTagCommand;
     private final CommentCommand commentCommand;
-
-    private final StatusRepository statusRepository;
+    private final StatusCommand statusCommand;
 
     private final CustomAuthorityUtils customAuthorityUtils;
     private final PasswordEncoder passwordEncoder;
@@ -62,7 +62,7 @@ public class UserServiceImpl implements UserService {
         repository.save(user); // 유저 저장
 
         // 유저 생성 시 기본 status 생성
-        createStatus(user);
+        statusCommand.createStatus(user);
     }
 
     // 유저 조회
@@ -114,6 +114,7 @@ public class UserServiceImpl implements UserService {
         feedCommand.deleteFeedAll(findUser.getUserId());
         feedHashTagCommand.deleteFeedHashtagAll(findUser.getUserId());
         commentCommand.deleteCommentAll(findUser.getUserId());
+        statusCommand.resetStatus(findUser.getUserId());
 
         repository.save(findUser);
     }
@@ -145,23 +146,5 @@ public class UserServiceImpl implements UserService {
         OptionalUser.ifPresent(user -> {
             throw new BusinessLogicException(ExceptionCode.USER_EXISTS_NICKNAME); // 닉네임이 이미 존재한다면 예외 발생
         });
-    }
-
-    // status 생성
-    private void createStatus(User user) {
-        List<Status> statusList = new ArrayList<>();
-        for(int i=1; i<=5 ; i++) {
-            Stat stat = new Stat();
-            stat.setStatId((long) i);
-
-            Status status = new Status();
-            status.setUser(user);
-            status.setStat(stat);
-            status.setStatLevel(1);
-            status.setStatExp(0);
-            status.setRequiredExp(100); // level1 -> level2 초기 필요 경험치
-            statusList.add(status);
-        }
-        statusRepository.saveAll(statusList);
     }
 }

--- a/Server/src/main/java/com/codestatus/domain/user/service/UserServiceImpl.java
+++ b/Server/src/main/java/com/codestatus/domain/user/service/UserServiceImpl.java
@@ -7,9 +7,6 @@ import com.codestatus.domain.status.command.StatusCommand;
 import com.codestatus.domain.user.command.UserCommand;
 import com.codestatus.global.auth.utils.CustomAuthorityUtils;
 import com.codestatus.global.aws.FileStorageService;
-import com.codestatus.domain.status.entity.Stat;
-import com.codestatus.domain.status.entity.Status;
-import com.codestatus.domain.status.repository.StatusRepository;
 import com.codestatus.global.exception.BusinessLogicException;
 import com.codestatus.global.exception.ExceptionCode;
 import com.codestatus.domain.user.entity.User;
@@ -20,7 +17,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -45,24 +41,51 @@ public class UserServiceImpl implements UserService {
     // 유저 생성
     @Override
     public void createEntity(User user) {
+        Optional<User> optionalUser = repository.findByEmail(user.getEmail()); // 가입 요청이 온 email 로 user table 검색
+
+        if (optionalUser.isPresent()) { // optional 객체의 값이 있는 경우
+            User findUser = optionalUser.get(); // optional 객체의 값을 get
+            if (findUser.getUserStatus().equals(User.UserStatus.USER_DELETE)) { // user status 값이 DELETE 라면
+                rejoinUser(findUser, user.getPassword(), user.getNickname()); // 재가입 메서드 실행
+            } else { // user status 의 값이 DELETE 가 아니라면
+                throw new BusinessLogicException(ExceptionCode.USER_EXISTS_EMAIL); // 중복 email 예외 발생
+            }
+        } else { // optional 객체의 값이 없는 경우
+            joinNewUser(user); // 새로운 유저 생성 메서드 실행
+        }
+    }
+
+    // 새로운 유저 생성 메서드
+    private void joinNewUser(User user) {
         verifyExistsEmail(user.getEmail()); // 이메일 중복 검사
         verifyExistsNickname(user.getNickname()); // 닉네임 중복 검사
         user.setPassword(passwordEncoder.encode(user.getPassword())); // 비밀번호 암호화
         List<String> roles = customAuthorityUtils.createRoles(user.getEmail()); // 권한 생성
         user.setRoles(roles); // 권한 저장
 
-        List<String> defaultImage = Arrays.asList( // 프로필 이미지
+        List<String> defaultImage = Arrays.asList( // 기본 프로필 이미지
                 "https://codestatus.s3.ap-northeast-2.amazonaws.com/default_profile_image1.png",
                 "https://codestatus.s3.ap-northeast-2.amazonaws.com/default_profile_image2.png",
                 "https://codestatus.s3.ap-northeast-2.amazonaws.com/default_profile_image3.png",
                 "https://codestatus.s3.ap-northeast-2.amazonaws.com/default_profile_image4.png");
-        int random = (int)(Math.random() * defaultImage.size());
+        int randomNum = (int)(Math.random() * defaultImage.size()); // 기본 프로필 이미지 list 의 사이즈만큼 랜덤 숫자 생성
 
-        user.setProfileImage(defaultImage.get(random)); // 프로필 이미지 랜덤 배정
+        user.setProfileImage(defaultImage.get(randomNum)); // 생성된 랜덤 숫자로 프로필 이미지 배정
         repository.save(user); // 유저 저장
+        statusCommand.createStatus(user); // status 생성
+    }
 
-        // 유저 생성 시 기본 status 생성
-        statusCommand.createStatus(user);
+    // 재가입 유저 메서드
+    private void rejoinUser(User findUser, String password, String nickname) {
+        findUser.setUserStatus(User.UserStatus.USER_ACTIVE); // user status 를 ACTIVE 로 변경
+        findUser.setPassword(passwordEncoder.encode(password)); // 비밀번호 암호화
+        if (findUser.getNickname().equals(nickname)) { // DB 의 닉네임과 재가입시 입력한 닉네임이 같다면
+            findUser.setNickname(nickname); // 중복검사를 하지 않고 닉네임 set
+        } else { // DB 의 닉네임과 재가입시 입력한 닉네임이 다르다면
+            verifyExistsNickname(nickname); // 다른 유저와의 닉네임 중복검사
+            findUser.setNickname(nickname); // 중복검사 통과시 닉네임 set
+        }
+        repository.save(findUser); // 유저 저장
     }
 
     // 유저 조회
@@ -111,12 +134,12 @@ public class UserServiceImpl implements UserService {
 
         findUser.setUserStatus(User.UserStatus.USER_DELETE); // 유저 상태를 탈퇴 상태로 변경
 
-        feedCommand.deleteFeedAll(findUser.getUserId());
-        feedHashTagCommand.deleteFeedHashtagAll(findUser.getUserId());
-        commentCommand.deleteCommentAll(findUser.getUserId());
-        statusCommand.resetStatus(findUser.getUserId());
+        feedCommand.deleteFeedAll(findUser.getUserId()); // 유저가 작성한 feed 삭제
+        feedHashTagCommand.deleteFeedHashtagAll(findUser.getUserId()); // 유저가 작성한 hashtag 삭제
+        commentCommand.deleteCommentAll(findUser.getUserId()); // 유저가 작성한 comment 삭제
+        statusCommand.resetStatus(findUser.getUserId()); // 유저가 가진 status 정보 초기화
 
-        repository.save(findUser);
+        repository.save(findUser); // 유저 저장
     }
 
     // 프로필 이미지 업로드


### PR DESCRIPTION
🐛 fix: user 탈퇴시 status 정보 초기화 및 status 생성 메서드 StatusCommand 클래스로 이동
- StatusCommnad 클래스 생성
- UserServiceImpl 에 있던 createStatus() 를 StatusCommand 로 이동
- status 를 초기화하는 resetStatus() 추가
- user 탈퇴시 해당 user 가 가진 status 정보를 초기화

🐛 fix: 탈퇴한 user 가 재가입 요청시 처리하는 메서드 추가
1. 가입 요청이 온 email 로 user table 검색
2. email 이 존재하는 경우 재가입 메서드 실행
3. email 이 존재하지 않으면 새로운 유저 생성 메서드 실행

Test Case
1. 유저 탈퇴시 status 초기화 확인 완료
2. 새로운 유저 생성 확인 완료
3. DELETE 상태 유저가 재가입 하려는 경우
      ㄴ 유저 상태 변경 확인 완료(DELETE -> ACTIVE)
      ㄴ 기존과 다른 닉네임을 입력한 경우 닉네임 중복검사 후 저장 확인 완료
      ㄴ 기존과 같은 닉네임을 입력한 경우 기존 닉네임 사용 확인 완료
      ㄴ 비밀번호는 새로 입력한 비밀번호를 암호화해서 저장 및 로그인 확인 완료