### PR TITLE
✨ feat: 유저 프로필 이미지 초기화 기능 추가

### DIFF
--- a/Server/src/main/java/com/codestatus/domain/user/controller/UserController.java
+++ b/Server/src/main/java/com/codestatus/domain/user/controller/UserController.java
@@ -65,7 +65,7 @@ public class UserController {
         return ResponseEntity.status(HttpStatus.OK).body("password patch success"); // 비밀번호 수정 성공 메시지 반환
     }
 
-    // 프로필 이미지 업로드
+    // 프로필 이미지 업로드 컨트롤러
     @PostMapping("/mypage/edit/image")
     public ResponseEntity uploadProfileImage(@RequestParam("imageFile") MultipartFile imageFile,
                                              @AuthenticationPrincipal PrincipalDto principal) {
@@ -73,7 +73,14 @@ public class UserController {
         return ResponseEntity.status(HttpStatus.OK).body("profile image upload success"); // 프로필 이미지 업로드 성공 메시지 반환
     }
 
-    // 유저 탈퇴
+    // 프로필 이미지 초기화 컨트롤러
+    @PatchMapping("/mypage/reset/image")
+    public ResponseEntity resetProfileImage(@AuthenticationPrincipal PrincipalDto principal) {
+        service.resetProfileImage(principal.getId());
+        return ResponseEntity.status(HttpStatus.OK).body("profile image reset success");
+    }
+
+    // 유저 탈퇴 컨트롤러
     @DeleteMapping("/mypage/delete")
     public ResponseEntity deleteUser(@AuthenticationPrincipal PrincipalDto principal) {
         service.deleteEntity(principal.getId()); // 유저 탈퇴 메서드 호출

--- a/Server/src/main/java/com/codestatus/domain/user/service/UserService.java
+++ b/Server/src/main/java/com/codestatus/domain/user/service/UserService.java
@@ -10,4 +10,5 @@ public interface UserService {
     void updatePassword(User user, long loginUserId);
     void deleteEntity(long loginUserId);
     void uploadProfileImage(MultipartFile imageFile, long loginUserId);
+    void resetProfileImage(long loginUserId);
 }

--- a/Server/src/main/java/com/codestatus/global/aws/FileStorageService.java
+++ b/Server/src/main/java/com/codestatus/global/aws/FileStorageService.java
@@ -2,6 +2,7 @@ package com.codestatus.global.aws;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.codestatus.global.exception.BusinessLogicException;
@@ -60,5 +61,12 @@ public class FileStorageService {
         String fileUrl = amazonS3.getUrl(bucketName, fileName).toString();
 
         return fileUrl;
+    }
+
+    public void deleteFile(String url) {
+        String splitStr = ".com/";
+        String fileName = url.substring(url.lastIndexOf(splitStr) + splitStr.length());
+
+        amazonS3.deleteObject(new DeleteObjectRequest(bucketName, fileName));
     }
 }

--- a/Server/src/main/java/com/codestatus/global/exception/ExceptionCode.java
+++ b/Server/src/main/java/com/codestatus/global/exception/ExceptionCode.java
@@ -25,6 +25,7 @@ public enum ExceptionCode {
 
     IMAGE_URL_ERROR(404, "이미지 URL을 찾을 수 없습니다.", "I000"),
     INVALID_FILE_TYPE(400, "이미지 파일만 업로드 가능합니다.", "I001"),
+    ALREADY_DEFAULT_IMAGE(400, "이미 기본 프로필 이미지를 사용 중 입니다.", "I002"),
 
     FILE_NOT_FOUND(404, "파일을 찾을 수 없습니다.", "f000"),
     FILE_TOO_LARGE(400, "파일 크기는 5MB를 넘을 수 없습니다.", "f001"),


### PR DESCRIPTION
✨ feat: 유저 프로필 이미지 초기화 기능 추가
- 유저의 프로필 이미지를 초기화하는 api 추가 했습니다.
- 초기화 요청시 사용중인 프로필 이미지를 s3 에서 삭제하고 기본 프로필 이미지 4개 중 하나로 배정 됩니다.
- 이미 기본 프로필을 사용 하고 있을 경우 예외가 발생합니다.(예외코드 I002 추가)

🐛 fix : 회원 탈퇴시 프로필 이미지 삭제
- 회원 탈퇴 진행시 유저가 업로드한 프로필 이미지 사용 중일때 해당 이미지를 s3 에서 삭제하고 기본 프로필 이미지로 배정 합니다.
- 이미 기본 프로필 이미지를 사용 하고 있을 경우 무시 됩니다.
- 기본 프로필 이미지 url List 중복 사용으로 클래스 내에서 사용 할 수 있게 변경
- 중복되는 로직 메서드로 변경(기본 프로필 이미지 배정 로직)
- rejoinUser() 내부 조건문 로직 변경

Test Case
- 프로필 이미지 초기화 및 s3 파일 삭제 확인 완료
- 기본 프로필 사용으로 인한 예외 발생 확인 완료
- 탈퇴시 업로드 한 프로필 이미지 삭제 및 기본 프로필 이미지로 변경 확인 완료
- 탈퇴시 이미 기본 프로필 이미지 일 경우 무시되는지 확인 완료