### PR TITLE
🐛fix: oauth2 인증 외 

### DIFF
--- a/Server/src/main/java/com/codestatus/domain/user/dto/UserDto.java
+++ b/Server/src/main/java/com/codestatus/domain/user/dto/UserDto.java
@@ -12,7 +12,7 @@ import java.util.List;
 public class UserDto {
     @Getter
     public static class signup {
-        @NotBlank(message = "비밀번호는 공백이 아니어야 합니다.")
+        @NotBlank(message = "이메일은 공백이 아니어야 합니다.")
         @Pattern(regexp = "^[a-zA-Z0-9+-_.]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$",
                 message = "이메일 형식이 올바르지 않습니다.")
         private String email;

--- a/Server/src/main/java/com/codestatus/domain/user/repository/UserRepository.java
+++ b/Server/src/main/java/com/codestatus/domain/user/repository/UserRepository.java
@@ -11,9 +11,8 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     // @Query(value = "SELECT * FROM users u WHERE u.email = :email", nativeQuery = true)
     Optional<User> findByEmail(String email); // @Param("email")
-
-    // @Query(value = "SELECT * FROM users u WHERE u.nick_name = :nickname", nativeQuery = true)
-    Optional<User> findByNickname(String nickName); // @Param("nickname")
+    long countAllByNicknameContains(String nickname);
+    boolean existsByNickname(String nickName);
 }
 
 /*

--- a/Server/src/main/java/com/codestatus/domain/user/service/UserService.java
+++ b/Server/src/main/java/com/codestatus/domain/user/service/UserService.java
@@ -4,7 +4,8 @@ import com.codestatus.domain.user.entity.User;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface UserService {
-    void createEntity(User user);
+    User createEntity(User user);
+    User createOauthUser(String email);
     User findEntity(long userId);
     void updateUserNickname(User user, long loginUserId);
     void updatePassword(User user, long loginUserId);

--- a/Server/src/main/java/com/codestatus/global/auth/config/SecurityConfig.java
+++ b/Server/src/main/java/com/codestatus/global/auth/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.codestatus.global.auth.config;
 
+import com.codestatus.domain.user.service.UserService;
 import com.codestatus.global.auth.filter.JwtAuthenticationFilter;
 import com.codestatus.global.auth.filter.JwtVerificationFilter;
 import com.codestatus.global.auth.handler.*;
@@ -30,7 +31,8 @@ import java.util.Arrays;
 public class SecurityConfig {
     private final JwtTokenizer jwtTokenizer;
     private final CustomAuthorityUtils authorityUtils;
-    private final UsersDetailService userService;
+    private final UsersDetailService usersDetailService;
+    private final UserService userService;
     private final JwtResponseUtil jwtResponseUtil;
     private String s3 = "http://statandus.s3-website.ap-northeast-2.amazonaws.com/"; // front 배포 완료되면 s3 주소 여기에 넣으면 됨
 
@@ -96,7 +98,7 @@ public class SecurityConfig {
                         .anyRequest().permitAll() // 나머지 요청은 누구나 가능
                 )
                 .oauth2Login(oauth2 -> oauth2
-                        .successHandler(new OAuth2UserSuccessHandler(jwtTokenizer, userService)));
+                        .successHandler(new OAuth2UserSuccessHandler(jwtTokenizer, usersDetailService, userService)));
                 return http.build();
     }
 
@@ -131,7 +133,7 @@ public class SecurityConfig {
             jwtAuthenticationFilter.setAuthenticationSuccessHandler(new UserAuthenticationSuccessHandler());
             jwtAuthenticationFilter.setAuthenticationFailureHandler(new UserAuthenticationFailureHandler());
 
-            JwtVerificationFilter jwtVerificationFilter = new JwtVerificationFilter(jwtTokenizer, authorityUtils, userService, jwtResponseUtil);
+            JwtVerificationFilter jwtVerificationFilter = new JwtVerificationFilter(jwtTokenizer, authorityUtils, usersDetailService, jwtResponseUtil);
 
             builder
                     .addFilter(jwtAuthenticationFilter)

--- a/Server/src/main/java/com/codestatus/global/auth/handler/OAuth2UserSuccessHandler.java
+++ b/Server/src/main/java/com/codestatus/global/auth/handler/OAuth2UserSuccessHandler.java
@@ -24,7 +24,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class OAuth2UserSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
     private final JwtTokenizer jwtTokenizer;
-    private final UsersDetailService usersDetailServiceService;
+    private final UsersDetailService usersDetailService;
     private final UserService userService;
 
     @Override
@@ -36,7 +36,7 @@ public class OAuth2UserSuccessHandler extends SimpleUrlAuthenticationSuccessHand
         MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         User user;
         try {
-            user = usersDetailServiceService.loadUserByEmail(email);
+            user = usersDetailService.loadUserByEmail(email);
 
         } catch (UsernameNotFoundException e){
            user = userService.createOauthUser(email);

--- a/Server/src/main/java/com/codestatus/global/auth/handler/OAuth2UserSuccessHandler.java
+++ b/Server/src/main/java/com/codestatus/global/auth/handler/OAuth2UserSuccessHandler.java
@@ -1,5 +1,7 @@
 package com.codestatus.global.auth.handler;
 
+import com.codestatus.domain.user.service.UserService;
+import com.codestatus.domain.user.service.UserServiceImpl;
 import com.codestatus.global.auth.jwt.JwtTokenizer;
 import com.codestatus.global.auth.userdetails.UsersDetailService;
 import com.codestatus.domain.user.entity.User;
@@ -17,15 +19,13 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.net.URI;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 @RequiredArgsConstructor
 public class OAuth2UserSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
     private final JwtTokenizer jwtTokenizer;
-    private final UsersDetailService userService;
+    private final UsersDetailService usersDetailServiceService;
+    private final UserService userService;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
@@ -34,13 +34,16 @@ public class OAuth2UserSuccessHandler extends SimpleUrlAuthenticationSuccessHand
         String email = getEmail(oAuth2User);
         String path = "";
         MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
+        User user;
         try {
-            User user = userService.loadUserByEmail(email);
-            queryParams.add("access_token", jwtTokenizer.generateAccessToken(user));
-            queryParams.add("refresh_token", jwtTokenizer.generateRefreshToken(user));
+            user = usersDetailServiceService.loadUserByEmail(email);
+
         } catch (UsernameNotFoundException e){
-            path = "/oauth";
+           user = userService.createOauthUser(email);
         }
+
+        queryParams.add("access_token", jwtTokenizer.generateAccessToken(user));
+        queryParams.add("refresh_token", jwtTokenizer.generateRefreshToken(user));
         String uri = createURI(queryParams, path).toString();
         getRedirectStrategy().sendRedirect(request, response, uri);
     }
@@ -49,14 +52,13 @@ public class OAuth2UserSuccessHandler extends SimpleUrlAuthenticationSuccessHand
         Map<String, Object> kakaoAccount = (Map<String, Object>) oAuth2User.getAttributes().get("kakao_account");
         return (String) kakaoAccount.get("email");
     }
-
     private URI createURI(MultiValueMap<String, String> queryParams, String path) {
         return UriComponentsBuilder
                 .newInstance()
                 .scheme("http")
-                .host("localhost")
+                .host("statandus.s3-website.ap-northeast-2.amazonaws.com")
 //                .port(80)
-                .path(path)
+                .path("auth/login")
                 .queryParams(queryParams)
                 .build()
                 .toUri();


### PR DESCRIPTION
🐛fix: email validation message
- 회원 가입 시 email validation check message가 잘못 되어있던 것 수정

✨feat: count nickname & ♻️refactor: check nickname
- 닉네임 생성기에서 이메일의 앞부분을 사용하는 유저 수를 가져와
비슷한 닉네임이 있을 시 해당 수 만큼 닉네임 뒤에 더함
- verifiedNickname 메서드에서 jpa의 exists 사용

✨ feat: Oauth User 자동 가입 추가 & 🐛 fix: oauth2 인증 user redirect uri 수정
- Oauth2를 사용한 사용자 인증 시 리소스 서버로 부터 email을 가져와
User 테이블에 존재 시 로그인, 아닐 때 닉네임과 패스워드를 생성해서 
새로운 데이터를 생성한 뒤  uri에 access token과 refresh token을 포함해 redirect

Test Case:
- google, kakao 둘 다 회원 생성 확인하였습니다.